### PR TITLE
Rename config structure

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -51,7 +51,7 @@ var (
 		Long:  "Backup Kubernetes cluster as yaml files in a git repository",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conf := &config.KdnConfig{
+			conf := &config.KfConfig{
 				DryRun:        viper.GetBool("dry-run"),
 				Logger:        klog.New(viper.GetString("log.level"), viper.GetString("log.server"), viper.GetString("log.output")),
 				LocalDir:      viper.GetString("local-dir"),

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// KdnConfig is the configuration struct, passed to controllers's Init()
-type KdnConfig struct {
+// KfConfig is the configuration struct, passed to controllers's Init()
+type KfConfig struct {
 	// When DryRun is true, we display but don't really send notifications
 	DryRun bool
 
@@ -44,7 +44,7 @@ type KdnConfig struct {
 }
 
 // Init initialize the config
-func (c *KdnConfig) Init(apiserver string, kubeconfig string) (err error) {
+func (c *KfConfig) Init(apiserver string, kubeconfig string) (err error) {
 	c.Client, err = client.NewRestConfig(apiserver, kubeconfig)
 	if err != nil {
 		return fmt.Errorf("Failed init Kubernetes clientset: %+v", err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,13 +42,13 @@ type Controller struct {
 	doneCh   chan struct{}
 	evchan   chan Event
 	name     string
-	config   *config.KdnConfig
+	config   *config.KfConfig
 	queue    workqueue.RateLimitingInterface
 	informer cache.SharedIndexInformer
 }
 
 // NewController return an untyped, generic Kubernetes controller
-func NewController(lw cache.ListerWatcher, evchan chan Event, name string, config *config.KdnConfig) *Controller {
+func NewController(lw cache.ListerWatcher, evchan chan Event, name string, config *config.KfConfig) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	informer := cache.NewSharedIndexInformer(

--- a/pkg/controller/observer.go
+++ b/pkg/controller/observer.go
@@ -26,7 +26,7 @@ type Observer struct {
 	disc   *discovery.DiscoveryClient
 	cpool  dynamic.ClientPool
 	ctrls  map[string]*Controller
-	config *config.KdnConfig
+	config *config.KfConfig
 }
 
 type gvk struct {
@@ -40,7 +40,7 @@ type gvk struct {
 type resources map[string]*gvk
 
 // NewObserver creates a new observer, to create an manage Kubernetes controllers
-func NewObserver(config *config.KdnConfig, evch chan Event) *Observer {
+func NewObserver(config *config.KfConfig, evch chan Event) *Observer {
 	return &Observer{
 		config: config,
 		evch:   evch,
@@ -164,7 +164,7 @@ func (c *Observer) expandAndFilterAPIResources(groups []*metav1.APIResourceList)
 	}
 
 	// remove lower priorities "cohabitations". cf. kubernetes/cmd/kube-apiserver/app/server.go
-	// (the api server may expose some resources under various api groups for backward compat...)
+	// (the api server may expose some resources under several api groups for backward compat...)
 	for preferred, obsolete := range preferredVersions {
 		if _, ok := resources[preferred]; ok {
 			delete(resources, obsolete)

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -12,13 +12,13 @@ import (
 
 // Listener is an http health check listener
 type Listener struct {
-	config *config.KdnConfig
+	config *config.KfConfig
 	donech chan struct{}
 	srv    *http.Server
 }
 
 // New create a new http health check listener
-func New(config *config.KdnConfig) *Listener {
+func New(config *config.KfConfig) *Listener {
 	return &Listener{
 		config: config,
 		donech: make(chan struct{}),

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -16,7 +16,7 @@ type activeFiles map[string]bool
 
 // Listener receive events from controllers and save them to disk as yaml files
 type Listener struct {
-	config      *config.KdnConfig
+	config      *config.KfConfig
 	evchan      chan controller.Event
 	actives     activeFiles
 	activesLock sync.RWMutex
@@ -25,7 +25,7 @@ type Listener struct {
 }
 
 // New creates a new Listener
-func New(config *config.KdnConfig, evchan chan controller.Event) *Listener {
+func New(config *config.KfConfig, evchan chan controller.Event) *Listener {
 	return &Listener{
 		config:  config,
 		evchan:  evchan,

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Run launchs the services
-func Run(config *config.KdnConfig) {
+func Run(config *config.KfConfig) {
 	repo, err := git.New(config).Start()
 	if err != nil {
 		config.Logger.Fatalf("failed to start git repo handler: %v", err)

--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -34,7 +34,7 @@ type Store struct {
 }
 
 // New instantiate a new Store
-func New(config *config.KdnConfig) *Store {
+func New(config *config.KfConfig) *Store {
 	return &Store{
 		Logger:   config.Logger,
 		URL:      config.GitURL,


### PR DESCRIPTION
"KdnConfig" had no meaning. "KfConfig" is better, stands for "Katafygio config".