### PR TITLE
Allow label filters

### DIFF
--- a/pkg/controller/observer.go
+++ b/pkg/controller/observer.go
@@ -110,7 +110,7 @@ func (c *Observer) refresh() error {
 
 		client := cl.Resource(res.ar.DeepCopy(), metav1.NamespaceAll)
 
-		selector := metav1.ListOptions{}
+		selector := metav1.ListOptions{LabelSelector: c.config.Filter}
 		lw := &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				return client.List(selector)


### PR DESCRIPTION
Using labels specifiers, we can filter to backup just a select set of applications,
eg. `-l 'k8s-app in (kube-dns, traefik)'`