### PR TITLE
Move observer to his own dedicated package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ lint:
 		--enable=structcheck \
 		--enable=deadcode \
 		--enable=ineffassign \
+		--enable=dupl \
 		--enable=gotype \
 		--enable=varcheck \
 		--enable=interfacer \

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -52,8 +52,8 @@ type Controller struct {
 	informer cache.SharedIndexInformer
 }
 
-// NewController return an untyped, generic Kubernetes controller
-func NewController(lw cache.ListerWatcher, evchan chan Event, name string, config *config.KfConfig) *Controller {
+// New return an untyped, generic Kubernetes controller
+func New(lw cache.ListerWatcher, evchan chan Event, name string, config *config.KfConfig) *Controller {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	informer := cache.NewSharedIndexInformer(

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bpineau/katafygio/config"
 	"github.com/bpineau/katafygio/pkg/controller"
 	"github.com/bpineau/katafygio/pkg/health"
+	"github.com/bpineau/katafygio/pkg/observer"
 	"github.com/bpineau/katafygio/pkg/recorder"
 	"github.com/bpineau/katafygio/pkg/store/git"
 )
@@ -24,7 +25,7 @@ func Run(config *config.KfConfig) {
 	evchan := make(chan controller.Event)
 
 	reco := recorder.New(config, evchan).Start()
-	ctrl := controller.NewObserver(config, evchan).Start()
+	ctrl := observer.New(config, evchan).Start()
 
 	http, err := health.New(config).Start()
 	if err != nil {


### PR DESCRIPTION
While adding package documentation, it became clear
that the observer does not belong to controller.