### PR TITLE
Move user provided object filter to controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,6 +7,7 @@ package controller
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bpineau/katafygio/config"
@@ -159,6 +160,12 @@ func (c *Controller) processItem(key string) error {
 
 	if err != nil {
 		return fmt.Errorf("error fetching %s from store: %v", key, err)
+	}
+
+	for _, obj := range c.config.ExcludeObject {
+		if strings.Compare(strings.ToLower(obj), strings.ToLower(c.name+":"+key)) == 0 {
+			return nil
+		}
 	}
 
 	if !exists {


### PR DESCRIPTION
This is where it belongs (even though implementing this
at recorder stage worked as well). No need to process
the event all along up to recorder.

TODO: make the filter list a map, so lookups would not
need as much cpu time.