### PR TITLE
De-constify default time intervals in git store

### DIFF
--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	timeoutCommands = 60 * time.Second
 	checkInterval   = 10 * time.Second
 )


### PR DESCRIPTION
This to permit overrides (in tests and beyond).