### PR TITLE
Fix a race condition in recorder tests

### DIFF
--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -28,7 +28,7 @@ func TestRecorder(t *testing.T) {
 	conf := &config.KfConfig{
 		Logger:     log.New("info", "", "test"),
 		LocalDir:   "/tmp/ktest", // fake dir (in memory fs provided by Afero)
-		ResyncIntv: 60,
+		ResyncIntv: 60 * time.Second,
 	}
 
 	rec := New(conf, evt).Start()
@@ -71,7 +71,7 @@ func TestDryRunRecorder(t *testing.T) {
 	conf := &config.KfConfig{
 		Logger:     log.New("info", "", "test"),
 		LocalDir:   "/tmp/ktest",
-		ResyncIntv: 60,
+		ResyncIntv: 60 * time.Second,
 	}
 
 	conf.DryRun = true
@@ -106,7 +106,7 @@ func TestFailingFSRecorder(t *testing.T) {
 	conf := &config.KfConfig{
 		Logger:     log.New("info", "", "test"),
 		LocalDir:   "/tmp/ktest", // fake dir (in memory fs provided by Afero)
-		ResyncIntv: 60,
+		ResyncIntv: 60 * time.Second,
 	}
 
 	rec := New(conf, evt).Start()


### PR DESCRIPTION
When we switch the filesystem under a running recorder during
failure tests, we don't want the garbage collection
deleteObsoleteFiles() to run at the same time, since he may
well be traversing the filesystem being replaced.
And using the real expected type/unit (time) is always better.