### PR TITLE
Prevent git from considering .git in parent directories

### DIFF
--- a/pkg/store/git/git_test.go
+++ b/pkg/store/git/git_test.go
@@ -106,7 +106,7 @@ func TestGit(t *testing.T) {
 	repo.LocalDir = newdir
 	repo.URL = dir
 
-	err = repo.Clone()
+	err = repo.CloneOrInit()
 	if err != nil {
 		t.Errorf("clone failed: %v", err)
 	}


### PR DESCRIPTION
When the target directory doesn't (yet) contains .git, git
will look for this .git directory recursively on parent
directories. We'd rather have git to fail rather than using
a random .git in an upper directory.