### PR TITLE
Increase resync interval

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -137,7 +137,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVarP(&healthP, "healthcheck-port", "p", 0, "Port for answering healthchecks on /health url")
 	bindPFlag("healthcheck-port", "healthcheck-port")
 
-	RootCmd.PersistentFlags().IntVarP(&resync, "resync-interval", "i", 300, "Resync interval in seconds (0 to disable)")
+	RootCmd.PersistentFlags().IntVarP(&resync, "resync-interval", "i", 900, "Full resync interval in seconds (0 to disable)")
 	bindPFlag("resync-interval", "resync-interval")
 }
 


### PR DESCRIPTION
Due to the simplicity of our objects lifecycle (basicaly, files on disk),
we have very little chances of missing events, so we shouldn't obsess on
resyncing too frequently. This caused pointless burden on the api-server.