### PR TITLE
Prevent glog from writing to /tmp during tests

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -104,10 +104,10 @@ func init() {
 		log.Fatal("Failed to bind cli argument:", err)
 	}
 
-	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Dry-run mode: don't store anything.")
+	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Dry-run mode: don't store anything")
 	bindPFlag("dry-run", "dry-run")
 
-	RootCmd.PersistentFlags().BoolVarP(&dumpMode, "dump-only", "m", false, "Dump mode: dump everything and exit")
+	RootCmd.PersistentFlags().BoolVarP(&dumpMode, "dump-only", "m", false, "Dump mode: dump everything once and exit")
 	bindPFlag("dump-only", "dump-only")
 
 	RootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "info", "Log level")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"flag"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +74,7 @@ var (
 )
 
 func TestController(t *testing.T) {
+	flag.Lookup("logtostderr").Value.Set("true")
 
 	conf := &config.KfConfig{
 		Logger:        log.New("info", "", "test"),


### PR DESCRIPTION
glog (brought by client-go dep) registers an init() that configure the
default logger to write logs as files in /tmp. This is disabled by
sp13/pflags, which is loaded by default in Katafygio, but not during
tests.

So forcing glog to use stderr instead of files prevent a few files
from "leaking" in /tmp every time we run unit tests.