### PR TITLE
Fix resync interval duration

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -68,7 +68,7 @@ func New(client cache.ListerWatcher, notifier event.Notifier, name string, confi
 	informer := cache.NewSharedIndexInformer(
 		lw,
 		&unstructured.Unstructured{},
-		config.ResyncIntv*time.Second,
+		config.ResyncIntv,
 		cache.Indexers{},
 	)
 


### PR DESCRIPTION
Commit ee12452c tried to convert ResyncIntv to time.Duration,
which it was already, by multiplying this value to time.Second.