### PR TITLE
Enable all client-go auth plugins

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,23 @@
-hash: 2f95cb30e4948dcdb6309371c565bd756763193e33114c4e7e7a0b832331c776
-updated: 2018-04-11T22:00:40.906391283+02:00
+hash: fe585d19af780526ed9b11ed48a3e8cc0b4c5d9c2215e9de96fba41e4b737b1a
+updated: 2018-04-20T09:13:34.227355313+02:00
 imports:
 - name: cloud.google.com/go
   version: 20d4028b8a750c2aca76bf9fefa8ed2d0109b573
   subpackages:
   - compute/metadata
+- name: github.com/Azure/go-autorest
+  version: fc3b03a2d2d1f43fad3007038bd16f044f870722
+  subpackages:
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/date
 - name: github.com/davecgh/go-spew
   version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/ghodss/yaml
@@ -36,6 +45,15 @@ imports:
   - OpenAPIv2
   - compiler
   - extensions
+- name: github.com/gophercloud/gophercloud
+  version: c38d3807cb5863eb95a857d694f6a4d6b31cde32
+  subpackages:
+  - openstack
+  - openstack/identity/v2/tenants
+  - openstack/identity/v2/tokens
+  - openstack/identity/v3/tokens
+  - openstack/utils
+  - pagination
 - name: github.com/hashicorp/golang-lru
   version: 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
   subpackages:
@@ -86,7 +104,7 @@ imports:
 - name: github.com/spf13/jwalterweatherman
   version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
   version: b5e8006cbee93ec955a89ab31e0e3ce3204f3736
 - name: golang.org/x/crypto
@@ -282,8 +300,12 @@ imports:
   - pkg/apis/clientauthentication
   - pkg/apis/clientauthentication/v1alpha1
   - pkg/version
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/azure
   - plugin/pkg/client/auth/exec
   - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - plugin/pkg/client/auth/openstack
   - rest
   - rest/fake
   - rest/watch

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,8 @@ import:
   subpackages:
   - kubernetes
   - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/azure
+  - plugin/pkg/client/auth/oidc
   - rest
   - tools/clientcmd
   - tools/cache
@@ -37,3 +39,5 @@ import:
   version: ^1.0.0
 - package: github.com/spf13/afero
   version: ^1.1.0
+- package: github.com/Azure/go-autorest
+  version: v9.10.0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 
-	// Ensure we have GCP auth method linked in
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// Ensure we have auth plugins (gcp, azure, openstack, ...) linked in
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // NewRestConfig create a *rest.Config, trying to mimic kubectl behavior:


### PR DESCRIPTION
This brings in auth plugins for Azure, OpenStack, OpenID connect...
NB: fixing the Azure/go-autorest dep to v9.10.0, since newer (v10+)
releases aren't compatible with client-go (v7.0.0) anymore.