### PR TITLE
Use []byte for event body

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -186,7 +186,7 @@ func (c *Controller) processItem(key string) error {
 
 	if !exists {
 		// deleted object
-		c.enqueue(&event.Notification{Action: event.Delete, Key: key, Kind: c.name, Object: ""})
+		c.enqueue(&event.Notification{Action: event.Delete, Key: key, Kind: c.name, Object: nil})
 		return nil
 	}
 
@@ -207,7 +207,7 @@ func (c *Controller) processItem(key string) error {
 		return fmt.Errorf("failed to marshal %s: %v", key, err)
 	}
 
-	c.enqueue(&event.Notification{Action: event.Upsert, Key: key, Kind: c.name, Object: string(yml)})
+	c.enqueue(&event.Notification{Action: event.Upsert, Key: key, Kind: c.name, Object: yml})
 	return nil
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -110,7 +110,7 @@ func TestController(t *testing.T) {
 	gotFoo2 := false
 	for _, ev := range evt.evts {
 		// ensure cleanup filters works as expected
-		if strings.Contains(ev.Object, "shouldnotbethere") {
+		if strings.Contains(string(ev.Object), "shouldnotbethere") {
 			t.Error("object cleanup filters didn't work")
 		}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -17,7 +17,7 @@ type Notification struct {
 	Action Action
 	Key    string
 	Kind   string
-	Object string
+	Object []byte
 }
 
 // Notifier mediates notifications between controllers and recorder

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -10,7 +10,7 @@ var (
 		Action: Upsert,
 		Key:    "foo",
 		Kind:   "bar",
-		Object: "spam egg",
+		Object: []byte("spam egg"),
 	}
 )
 

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -126,7 +126,7 @@ func (w *Listener) relativePath(file string) string {
 	return strings.Replace(file, root+"/", "", 1)
 }
 
-func (w *Listener) save(file string, data string) error {
+func (w *Listener) save(file string, data []byte) error {
 	w.config.Logger.Debugf("Saving %s to disk", file)
 
 	if w.config.DryRun {
@@ -144,19 +144,10 @@ func (w *Listener) save(file string, data string) error {
 	w.actives[w.relativePath(file)] = true
 	w.activesLock.Unlock()
 
-	f, err := appFs.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to create %s on disk: %v", file, err)
-	}
+	err = afero.WriteFile(appFs, file, data, 0600)
 
-	_, err = f.WriteString(data)
 	if err != nil {
 		return fmt.Errorf("failed to write to %s on disk: %v", file, err)
-	}
-
-	err = f.Close()
-	if err != nil {
-		return fmt.Errorf("failed to close %s file: %v", file, err)
 	}
 
 	return nil

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -16,7 +16,7 @@ func newNotif(action event.Action, key string) *event.Notification {
 		Action: action,
 		Key:    key,
 		Kind:   "foo",
-		Object: "bar",
+		Object: []byte("bar"),
 	}
 }
 
@@ -116,7 +116,7 @@ func TestFailingFSRecorder(t *testing.T) {
 	// switching to failing (read-only) filesystem
 	appFs = afero.NewReadOnlyFs(appFs)
 
-	err := rec.save("foo", "bar")
+	err := rec.save("foo", []byte("bar"))
 	if err == nil {
 		t.Error("save should return an error in case of failure")
 	}


### PR DESCRIPTION
Using []byte rather than string is cleaner:
* That's what we get from yaml.Marshal, and what Write() to file will do
* Easier to make things io.Reader / io.Writer interface compliant