### PR TITLE
Keep file checksum in memory

### DIFF
--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -36,6 +36,7 @@ func TestRecorder(t *testing.T) {
 	evt.Send(newNotif(event.Upsert, "foo1"))
 	evt.Send(newNotif(event.Upsert, "foo2"))
 	evt.Send(newNotif(event.Delete, "foo1"))
+	evt.Send(newNotif(event.Upsert, "foo2"))
 
 	rec.Stop() // to flush ongoing fs operations
 


### PR DESCRIPTION
To avoid re-writing the same file at each resync.
This shouldn't make a huge performance difference, except on
very slow storage devices, but keeping the mtime/ctime
timestamps unchanged may be helpful.

Note that we don't compare file checksums to files collected
from an existing repository during the first clone & resync
(we'll dump every cluster object once in any case).