### PR TITLE
Export the git config settings

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -46,7 +46,7 @@ var (
 				return fmt.Errorf("Failed to initialize the configuration: %v", err)
 			}
 
-			run.Run(conf) // <- this is where things happens
+			run.Run(conf) // <- this is where things happen
 			return nil
 		},
 	}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -1,4 +1,4 @@
-// Package recorder listen for events notification from controllers,
+// Package recorder listen for event notifications from controllers,
 // and persists those events' content as files on disk.
 package recorder
 
@@ -38,7 +38,7 @@ type Listener struct {
 	donech      chan struct{}
 }
 
-// New creates a new Listener
+// New creates a new event Listener
 func New(config *config.KfConfig, events event.Notifier) *Listener {
 	return &Listener{
 		config:  config,
@@ -47,7 +47,7 @@ func New(config *config.KfConfig, events event.Notifier) *Listener {
 	}
 }
 
-// Start receive events and saves them to disk as files
+// Start continuously receive events and saves them to disk as files
 func (w *Listener) Start() *Listener {
 	w.config.Logger.Info("Starting event recorder")
 	err := appFs.MkdirAll(filepath.Clean(w.config.LocalDir), 0700)

--- a/pkg/store/git/doc.go
+++ b/pkg/store/git/doc.go
@@ -1,0 +1,7 @@
+// Package git makes a git repository out of a local directory, keeps the
+// content committed when the directory content changes, and optionaly (if
+// a remote repos url is provided), keep it in sync with a remote repository.
+//
+// It requires the git command in $PATH, since the pure Go git implementations
+// aren't up to the task (see go-git issues #793 and #785 for instance).
+package git

--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -1,12 +1,3 @@
-// We'd love a working pure Go implementation. But so far we didn't find any
-// that would work for us. src-d/go-git is innapropriate due to
-// https://github.com/src-d/go-git/issues/793 and
-// https://github.com/src-d/go-git/issues/785 . And binding to the libgit C lib
-// aren't pure Go either. So we need the git binary for now.
-
-// Package git makes a git repository out of a local directory, keeps the
-// content committed when the directory content changes, and optionaly (if
-// a remote repos url is provided), keep it in sync with a remote repository.
 package git
 
 import (
@@ -23,11 +14,20 @@ import (
 )
 
 var (
-	timeoutCommands = 60 * time.Second
-	checkInterval   = 10 * time.Second
-	gitAuthor       = "Katafygio"
-	gitEmail        = "katafygio@localhost"
-	gitMsg          = "Kubernetes cluster change"
+	// TimeoutCommands defines the max execution time for git commands
+	TimeoutCommands = 60 * time.Second
+
+	// CheckInterval defines the interval between local directory checks
+	CheckInterval = 10 * time.Second
+
+	// GitAuthor is the name of the commiter
+	GitAuthor = "Katafygio"
+
+	// GitEmail is the email of the commiter
+	GitEmail = "katafygio@localhost"
+
+	// GitMsg is the commit message we'll use
+	GitMsg = "Kubernetes cluster change"
 )
 
 var appFs = afero.NewOsFs()
@@ -51,9 +51,9 @@ func New(config *config.KfConfig) *Store {
 		Logger:   config.Logger,
 		URL:      config.GitURL,
 		LocalDir: config.LocalDir,
-		Author:   gitAuthor,
-		Email:    gitEmail,
-		Msg:      gitMsg,
+		Author:   GitAuthor,
+		Email:    GitEmail,
+		Msg:      GitMsg,
 		DryRun:   config.DryRun,
 	}
 }
@@ -70,7 +70,7 @@ func (s *Store) Start() (*Store, error) {
 	}
 
 	go func() {
-		checkTick := time.NewTicker(checkInterval)
+		checkTick := time.NewTicker(CheckInterval)
 		defer checkTick.Stop()
 		defer close(s.donech)
 
@@ -100,7 +100,7 @@ func (s *Store) Git(args ...string) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutCommands)
+	ctx, cancel := context.WithTimeout(context.Background(), TimeoutCommands)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec
@@ -121,7 +121,7 @@ func (s *Store) Status() (changed bool, err error) {
 		return false, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutCommands)
+	ctx, cancel := context.WithTimeout(context.Background(), TimeoutCommands)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain") // #nosec


### PR DESCRIPTION
Other users of this package may want to override those
settings, so exporting and documenting them make this
just easier.

While at it, improve the inline doc.