### PR TITLE
Fix a race in recorder Start()/Stop()

### DIFF
--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -44,6 +44,8 @@ func New(config *config.KfConfig, events event.Notifier) *Listener {
 		config:  config,
 		events:  events,
 		actives: activeFiles{},
+		stopch:  make(chan struct{}),
+		donech:  make(chan struct{}),
 	}
 }
 
@@ -58,8 +60,6 @@ func (w *Listener) Start() *Listener {
 	go func() {
 		evCh := w.events.ReadChan()
 		gcTick := time.NewTicker(w.config.ResyncIntv * 2)
-		w.stopch = make(chan struct{})
-		w.donech = make(chan struct{})
 		defer gcTick.Stop()
 		defer close(w.donech)
 

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -142,6 +142,8 @@ func TestFailingFSRecorder(t *testing.T) {
 	// back to normal operations
 	rec.Stop() // just to flush ongoing ops before switch filesystem
 	appFs = afero.NewMemMapFs()
+	rec.stopch = make(chan struct{})
+	rec.donech = make(chan struct{})
 	rec.Start()
 	evt.Send(newNotif(event.Upsert, "foo2"))
 	rec.Stop() // flush ongoing ops


### PR DESCRIPTION
If a recorder is Stop()ed before he finished Start()ing,
he may not have created the channels used by Stop().
Those should be initialized at instanciation time, really.