### PR TITLE
More reusable pkg, step 1

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -48,15 +48,15 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 		ResyncIntv:    resync,
 	}
 
-	repo, err := git.New(conf).Start()
+	repo, err := git.New(logger, dryRun, localDir, gitURL).Start()
 	if err != nil {
 		conf.Logger.Fatalf("failed to start git repo handler: %v", err)
 	}
 
 	evts := event.New()
-	reco := recorder.New(conf, evts).Start()
+	reco := recorder.New(logger, evts, localDir, resyncInt*2, dryRun).Start()
 	obsv := observer.New(conf, evts, &controller.Factory{}).Start()
-	http := health.New(conf).Start()
+	http := health.New(logger, healthP).Start()
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -6,21 +6,26 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/bpineau/katafygio/config"
 )
+
+type logger interface {
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
 
 // Listener is an http health check listener
 type Listener struct {
-	config *config.KfConfig
+	logger logger
+	port   int
 	donech chan struct{}
 	srv    *http.Server
 }
 
 // New create a new http health check listener
-func New(config *config.KfConfig) *Listener {
+func New(log logger, port int) *Listener {
 	return &Listener{
-		config: config,
+		logger: log,
+		port:   port,
 		donech: make(chan struct{}),
 		srv:    nil,
 	}
@@ -28,19 +33,19 @@ func New(config *config.KfConfig) *Listener {
 
 func (h *Listener) healthCheckReply(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.WriteString(w, "ok\n"); err != nil {
-		h.config.Logger.Warningf("Failed to reply to http healtcheck from %s: %s\n", r.RemoteAddr, err)
+		h.logger.Errorf("Failed to reply to http healtcheck from %s: %s\n", r.RemoteAddr, err)
 	}
 }
 
 // Start exposes an http healthcheck handler
 func (h *Listener) Start() *Listener {
-	if h.config.HealthPort == 0 {
+	if h.port == 0 {
 		return h
 	}
 
-	h.config.Logger.Info("Starting http healtcheck handler")
+	h.logger.Infof("Starting http healtcheck handler")
 
-	h.srv = &http.Server{Addr: fmt.Sprintf(":%d", h.config.HealthPort)}
+	h.srv = &http.Server{Addr: fmt.Sprintf(":%d", h.port)}
 
 	http.HandleFunc("/health", h.healthCheckReply)
 
@@ -48,7 +53,7 @@ func (h *Listener) Start() *Listener {
 		defer close(h.donech)
 		err := h.srv.ListenAndServe()
 		if err != nil && err.Error() != "http: Server closed" {
-			h.config.Logger.Errorf("healthcheck server failed: %v", err)
+			h.logger.Errorf("healthcheck server failed: %v", err)
 		}
 	}()
 
@@ -61,11 +66,11 @@ func (h *Listener) Stop() {
 		return
 	}
 
-	h.config.Logger.Info("Stopping http healtcheck handler")
+	h.logger.Infof("Stopping http healtcheck handler")
 
 	err := h.srv.Shutdown(context.TODO())
 	if err != nil {
-		h.config.Logger.Warningf("failed to stop http healtcheck handler: %v", err)
+		h.logger.Errorf("failed to stop http healtcheck handler: %v", err)
 	}
 
 	<-h.donech

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -8,39 +8,29 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 
-	"github.com/bpineau/katafygio/config"
 	"github.com/bpineau/katafygio/pkg/log"
 )
 
+var logs = log.New("error", "", "test")
+
 func TestNoopHealth(t *testing.T) {
 
-	conf := &config.KfConfig{
-		Logger:     log.New("error", "", "test"),
-		HealthPort: 0,
-	}
-
 	// shouldn't panic with 0 as port
-	hc := New(conf)
+	hc := New(logs, 0)
 	_ = hc.Start()
 	hc.Stop()
 
-	conf.HealthPort = -42
-	hc = New(conf)
+	hc = New(logs, -42)
 	_ = hc.Start()
 	hc.Stop()
-	hook := hc.config.Logger.Hooks[logrus.InfoLevel][0].(*test.Hook)
+	hook := logs.Hooks[logrus.InfoLevel][0].(*test.Hook)
 	if len(hook.Entries) != 1 {
 		t.Error("Failed to log an issue with a bogus port")
 	}
 }
 
 func TestHealthCheck(t *testing.T) {
-	conf := &config.KfConfig{
-		Logger:     log.New("info", "", "test"),
-		HealthPort: 0,
-	}
-
-	hc := New(conf)
+	hc := New(logs, 0)
 
 	req, err := http.NewRequest("GET", "/health", nil)
 	if err != nil {


### PR DESCRIPTION
In the perspective of a reusable, generic pkg/ content:
* Reduce the scope expected from logger, and reduce it to a minimal interface
* Start to remove KfConfig (remains: observer and controller): pass
  naked arguments directly to packages constructors