### PR TITLE
Flat values for log config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ in uppercase, prefixed by "KF", and with underscore instead of dashs. ie.:
 ```
 export KF_GIT_URL=https://user:token@github.com/myorg/myrepos.git
 export KF_LOCAL_DIR=/tmp/kfdump
+export KF_LOG_LEVEL=info
 
 # exception, for kubectl compatibility:
 export KUBECONFIG=/tmp/kconfig

--- a/assets/katafygio.yaml
+++ b/assets/katafygio.yaml
@@ -4,10 +4,9 @@
 #api-server: http://127.0.0.1:8080
 #kube-config: /etc/kubernetes/config
 
-log:
-  level: "info"
-  output: "stderr"
-  #server: "localhost:514" # mandatory if log-output: "syslog"
+log-level: "info"
+log-output: "stderr"
+#log-server: "localhost:514" # mandatory if log-output: "syslog"
 
 # Where to save the yaml dumps
 local-dir: /var/cache/katafygio

--- a/cmd/configfile.go
+++ b/cmd/configfile.go
@@ -30,7 +30,7 @@ func loadConfigFile() {
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
-	if err := viper.ReadInConfig(); err == nil {
-		RootCmd.Printf("Using config file: %s", viper.ConfigFileUsed())
+	if err := viper.ReadInConfig(); err != nil {
+		RootCmd.Printf("Can't read config file: %v\n", err)
 	}
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -54,13 +54,13 @@ func init() {
 	bindPFlag("dump-only", "dump-only")
 
 	RootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "v", "info", "Log level")
-	bindPFlag("log.level", "log-level")
+	bindPFlag("log-level", "log-level")
 
 	RootCmd.PersistentFlags().StringVarP(&logOutput, "log-output", "o", "stderr", "Log output")
-	bindPFlag("log.output", "log-output")
+	bindPFlag("log-output", "log-output")
 
 	RootCmd.PersistentFlags().StringVarP(&logServer, "log-server", "r", "", "Log server (if using syslog)")
-	bindPFlag("log.server", "log-server")
+	bindPFlag("log-server", "log-server")
 
 	RootCmd.PersistentFlags().StringVarP(&localDir, "local-dir", "e", "./kubernetes-backup", "Where to dump yaml files")
 	bindPFlag("local-dir", "local-dir")
@@ -90,9 +90,9 @@ func bindConf(cmd *cobra.Command, args []string) {
 	kubeConf = viper.GetString("kube-config")
 	dryRun = viper.GetBool("dry-run")
 	dumpMode = viper.GetBool("dump-only")
-	logLevel = viper.GetString("log.level")
-	logOutput = viper.GetString("log.output")
-	logServer = viper.GetString("log.server")
+	logLevel = viper.GetString("log-level")
+	logOutput = viper.GetString("log-output")
+	logServer = viper.GetString("log-server")
 	filter = viper.GetString("filter")
 	localDir = viper.GetString("local-dir")
 	gitURL = viper.GetString("git-url")


### PR DESCRIPTION
Using a yaml dict for the log config (and only the log config)
wasn't really useful, made a gratuitous special case, and made
passing log conf as environment variable much harder.