### PR TITLE
Support Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -35,7 +35,10 @@ var (
 )
 
 func runE(cmd *cobra.Command, args []string) (err error) {
-	logger := log.New(logLevel, logServer, logOutput)
+	logger, err := log.New(logLevel, logServer, logOutput)
+	if err != nil {
+		return fmt.Errorf("failed to create a logger: %v", err)
+	}
 
 	if restcfg == nil {
 		restcfg, err = client.New(apiServer, kubeConf)

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -4,14 +4,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
-
-	"github.com/bpineau/katafygio/pkg/log"
 )
 
-var logs = log.New("error", "", "test")
+type mockLog struct {
+	count int
+}
+
+func (m *mockLog) Infof(format string, args ...interface{})  {}
+func (m *mockLog) Errorf(format string, args ...interface{}) { m.count++ }
+
+var logs = new(mockLog)
 
 func TestNoopHealth(t *testing.T) {
 
@@ -23,8 +25,7 @@ func TestNoopHealth(t *testing.T) {
 	hc = New(logs, -42)
 	_ = hc.Start()
 	hc.Stop()
-	hook := logs.Hooks[logrus.InfoLevel][0].(*test.Hook)
-	if len(hook.Entries) != 1 {
+	if logs.count != 1 {
 		t.Error("Failed to log an issue with a bogus port")
 	}
 }

--- a/pkg/log/output.go
+++ b/pkg/log/output.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log/syslog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	ls "github.com/sirupsen/logrus/hooks/syslog"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func getOutput(logServer string, logOutput string) (io.Writer, logrus.Hook, error) {
+	var output io.Writer
+	var hook logrus.Hook
+	var err error
+
+	switch logOutput {
+	case outputStdout:
+		output = os.Stdout
+	case outputStderr:
+		output = os.Stderr
+	case outputTest:
+		output = ioutil.Discard
+		_, hook = test.NewNullLogger()
+	case outputSyslog:
+		output = os.Stderr
+		if logServer == "" {
+			return nil, nil, fmt.Errorf("syslog output needs a log server (ie. 127.0.0.1:514)")
+		}
+		hook, err = ls.NewSyslogHook("udp", logServer, syslog.LOG_INFO, "katafygio")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to hook syslog output")
+		}
+	default:
+		output = os.Stderr
+	}
+
+	return output, hook, nil
+}

--- a/pkg/log/output_windows.go
+++ b/pkg/log/output_windows.go
@@ -1,0 +1,34 @@
+// +build windows
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func getOutput(logServer string, logOutput string) (io.Writer, logrus.Hook, error) {
+	var output io.Writer
+	var hook logrus.Hook
+
+	switch logOutput {
+	case outputStdout:
+		output = os.Stdout
+	case outputStderr:
+		output = os.Stderr
+	case outputTest:
+		output = ioutil.Discard
+		_, hook = test.NewNullLogger()
+	case outputSyslog:
+		return nil, nil, fmt.Errorf("Syslog output isn't supported on Windows")
+	default:
+		output = os.Stderr
+	}
+
+	return output, hook, nil
+}


### PR DESCRIPTION
The syslog logrus hook does not support Windows:
https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go
So we have to work around that.

While at it, ensure logger initialization errors are really
bubbling up, and prevent healthcheck tests from depending on
our logger implementation.