### PR TITLE
Move target folder creation at startup time

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"github.com/bpineau/katafygio/pkg/client"
@@ -22,6 +24,7 @@ const appName = "katafygio"
 
 var (
 	restcfg client.Interface
+	appFs   = afero.NewOsFs()
 
 	// RootCmd is our main entry point, launching runE()
 	RootCmd = &cobra.Command{
@@ -45,6 +48,11 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to create a client: %v", err)
 		}
+	}
+
+	err = appFs.MkdirAll(filepath.Clean(localDir), 0700)
+	if err != nil {
+		return fmt.Errorf("Can't create directory %s: %v", localDir, err)
 	}
 
 	repo, err := git.New(logger, dryRun, localDir, gitURL).Start()

--- a/cmd/execute_test.go
+++ b/cmd/execute_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/spf13/afero"
 	"k8s.io/client-go/rest"
 )
 
@@ -15,6 +16,7 @@ func (m *mockClient) GetRestConfig() *rest.Config {
 
 func TestRootCmd(t *testing.T) {
 	restcfg = new(mockClient)
+	appFs = afero.NewMemMapFs()
 	RootCmd.SetOutput(new(bytes.Buffer))
 	RootCmd.SetArgs([]string{
 		"--config",

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -62,10 +62,6 @@ func New(log logger, events event.Notifier, localDir string, gcInterval int, dry
 // Start continuously receive events and saves them to disk as files
 func (w *Listener) Start() *Listener {
 	w.logger.Infof("Starting event recorder")
-	err := appFs.MkdirAll(filepath.Clean(w.localDir), 0700)
-	if err != nil {
-		panic(fmt.Sprintf("Can't create directory %s: %v", w.localDir, err))
-	}
 
 	go func() {
 		evCh := w.events.ReadChan()


### PR DESCRIPTION
Where it belongs, so we can fail early and cleanly.
Also, doing that while on a separate goroutine was
pretty bad (since we'd have to either ignore the
error, or panic in a package).