### PR TITLE
New "--no-git" mode (don't version objects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This provides real time, continuous backups, and keeps detailled changes history
 
 To dump the cluster content once and exit:
 ```bash
-katafygio --dump-only --local-dir /tmp/clusterdump/
+katafygio --no-git --dump-only --local-dir /tmp/clusterdump/
 ```
 
 To create a local git repository and continuously save the cluster content:
@@ -73,6 +73,7 @@ Flags:
   -v, --log-level string         Log level (default "info")
   -o, --log-output string        Log output (default "stderr")
   -r, --log-server string        Log server (if using syslog)
+  -n, --no-git                   Don't version with git
   -i, --resync-interval int      Full resync interval in seconds (0 to disable) (default 900)
 ```
 

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -55,7 +55,10 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("Can't create directory %s: %v", localDir, err)
 	}
 
-	repo, err := git.New(logger, dryRun, localDir, gitURL).Start()
+	var repo *git.Store
+	if !noGit {
+		repo, err = git.New(logger, dryRun, localDir, gitURL).Start()
+	}
 	if err != nil {
 		return fmt.Errorf("failed to start git repo handler: %v", err)
 	}
@@ -74,9 +77,11 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	obsv.Stop()
-	repo.Stop()
 	reco.Stop()
 	http.Stop()
+	if !noGit {
+		repo.Stop()
+	}
 
 	return nil
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -23,6 +23,7 @@ var (
 	resyncInt int
 	exclkind  []string
 	exclobj   []string
+	noGit     bool
 )
 
 func bindPFlag(key string, cmd string) {
@@ -82,6 +83,9 @@ func init() {
 
 	RootCmd.PersistentFlags().IntVarP(&resyncInt, "resync-interval", "i", 900, "Full resync interval in seconds (0 to disable)")
 	bindPFlag("resync-interval", "resync-interval")
+
+	RootCmd.PersistentFlags().BoolVarP(&noGit, "no-git", "n", false, "Don't version with git")
+	bindPFlag("no-git", "no-git")
 }
 
 // for whatever the reason, viper don't auto bind values from config file so we have to tell him
@@ -100,4 +104,5 @@ func bindConf(cmd *cobra.Command, args []string) {
 	resyncInt = viper.GetInt("resync-interval")
 	exclkind = viper.GetStringSlice("exclude-kind")
 	exclobj = viper.GetStringSlice("exclude-object")
+	noGit = viper.GetBool("no-git")
 }


### PR DESCRIPTION
Useful for quick cluster dumps (when you're not interested in history),
or similar uses cases. Not everybody may need to version their clusters.