### PR TITLE
End-to-end tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,34 @@ language: go
 go:
   - "1.10.x"
 
+# only needed for e2e tests
+sudo: required
+
+env:
+  global:
+    # only needed for e2e tests
+    - K8S_VERSION=v1.10.0
+    - MINIKUBE_VERSION=v0.26.1
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_HOME=$HOME
+    - KUBECONFIG=$HOME/.kube/config
+
+# setup a minikube in travis-ci. only needed for e2e tests
+before_script:
+  - sudo curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+  - sudo curl -Lo /usr/local/bin/minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
+  - sudo chmod +x /usr/local/bin/kubectl /usr/local/bin/minikube
+  - mkdir -p $HOME/.kube && touch $HOME/.kube/config
+  # remove the --bootstrapper flag once this issue is solved: https://github.com/kubernetes/minikube/issues/2704
+  - sudo -E /usr/local/bin/minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=${K8S_VERSION}
+  # Fix the kubectl context, as it is often stale.
+  - /usr/local/bin/minikube update-context
+  # Wait for Kubernetes to be up and ready.
+  - for i in {1..150}; do kubectl get po &> /dev/null && break; sleep 2; done
+  - kubectl get ns
+
 install:
   - make tools
   - make deps
@@ -11,4 +39,5 @@ script:
   - make test
   - make coverall
   - make install
+  - make e2e
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ clean:
 coverall:
 	goveralls -coverprofile=profile.cov -service=travis-ci -package github.com/bpineau/katafygio/pkg/...
 
+e2e:
+	kubectl get ns >/dev/null || exit 1
+	go test -count=1 -v assets/e2e_test.go
+
 test:
 	go test -i github.com/bpineau/katafygio/...
 	go test -race -cover -coverprofile=profile.cov github.com/bpineau/katafygio/...

--- a/assets/e2e_test.go
+++ b/assets/e2e_test.go
@@ -1,0 +1,115 @@
+// +build ignore
+
+// end-to-end tests.
+// A kubernetes cluster must be reachable by kubectl and katafygio.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	checkTimeout  = 30 * time.Second
+	checkInterval = 1 * time.Second
+	dumpPath      = "/tmp/kf-e2e-test"
+)
+
+type dumpStep struct {
+	// a kubectl command to create a dumpable object
+	cmd string
+	// the counter-command, to purge the created object
+	teardown string
+	// the file that this command will eventually trigger katafygio to generate or delete
+	relpath string
+	// wether the file should be created or deleted
+	shouldExist bool
+}
+
+var testsTable = []dumpStep{
+	{"kubectl create ns kf-e2e-test-1", "kubectl delete ns kf-e2e-test-1", "namespace-kf-e2e-test-1.yaml", true},
+	{"kubectl run kf-e2e-test-2 --image=gcr.io/google_containers/pause-amd64:3.0", "kubectl delete deploy kf-e2e-test-2", "default/deployment-kf-e2e-test-2.yaml", true},
+	{"kubectl expose deployment kf-e2e-test-2 --port=80 --target-port=8000 --name=kf-e2e-test-3", "kubectl delete svc kf-e2e-test-3", "default/service-kf-e2e-test-3.yaml", true},
+	{"kubectl delete service kf-e2e-test-3", "", "default/service-kf-e2e-test-3.yaml", false},
+	{"kubectl delete namespace kf-e2e-test-1", "", "namespace-kf-e2e-test-1.yaml", false},
+	{"kubectl create configmap kf-e2e-test-4 --from-literal=key1=config1", "kubectl delete configmap kf-e2e-test-4", "default/configmap-kf-e2e-test-4.yaml", true},
+}
+
+func TestE2E(t *testing.T) {
+	for _, tt := range testsTable {
+		t.Run(tt.cmd, func(t *testing.T) {
+			err := tt.fileExists()
+			if err != nil {
+				t.Errorf("%s test failed (%v)", tt.cmd, err)
+			}
+		})
+
+	}
+}
+
+func TestMain(m *testing.M) {
+	deleteResources()
+	_ = exec.Command("rm", "-rf", dumpPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		cmd := exec.CommandContext(ctx, "katafygio", "-e", dumpPath)
+		_ = cmd.Run()
+	}()
+
+	ret := m.Run()
+	cancel()
+	deleteResources()
+	os.Exit(ret)
+}
+
+func deleteResources() {
+	for _, d := range testsTable {
+		if len(d.teardown) == 0 {
+			continue
+		}
+
+		command := strings.Split(d.teardown, " ")
+		_ = exec.Command(command[0], command[1:]...).Run()
+	}
+}
+
+func (d *dumpStep) fileExists() error {
+	checkTick := time.NewTicker(checkInterval)
+	timeoutTick := time.NewTicker(checkTimeout)
+	defer checkTick.Stop()
+	defer timeoutTick.Stop()
+
+	command := strings.Split(d.cmd, " ")
+	cmd := exec.Command(command[0], command[1:]...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed with code %v: %s", d.cmd, err, out)
+	}
+
+	for {
+		select {
+		case <-checkTick.C:
+			_, err := os.Stat(path.Join(dumpPath, d.relpath))
+
+			if err == nil && d.shouldExist {
+				return nil
+			}
+
+			if os.IsNotExist(err) && !d.shouldExist {
+				return nil
+			}
+
+		case <-timeoutTick.C:
+			return fmt.Errorf("timeout waiting for %s", d.relpath)
+		}
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -31,6 +31,7 @@ func TestClientSet(t *testing.T) {
 
 	_ = os.Unsetenv("KUBERNETES_SERVICE_HOST")
 	_ = os.Setenv("HOME", nonExistentPath)
+	_ = os.Setenv("KUBECONFIG", nonExistentPath)
 	_, err = New("", "")
 	if err == nil {
 		t.Fatal("New() should fail to load InClusterConfig without kube address env")


### PR DESCRIPTION
End-to-end tests
    
Setup minikube on Travis following this doc:
https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
    
This allow automated e2e tests for Katafygio, either localy - if you have a Kubernetes
(eg. minikube) reachable by kubectl and kafatafygio - or using Travis CI.
