### PR TITLE
Config: abort on parse errors

### DIFF
--- a/cmd/configfile.go
+++ b/cmd/configfile.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log"
 	"os"
 	"strings"
 
@@ -31,6 +32,9 @@ func loadConfigFile() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		RootCmd.Printf("Can't read config file: %v\n", err)
+		_, ok := err.(viper.ConfigParseError)
+		if ok {
+			log.Fatalf("Can't read config file: %v\n", err)
+		}
 	}
 }


### PR DESCRIPTION
Don't log warnings when no config file is found: this is a normal
situation, the configuration file isn't requiered in any way.

But if a configuration file is provided, it should parse without
errors.