### PR TITLE
Keep docker image up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make deps
 RUN make build
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates git
+RUN apk upgrade --no-cache && apk --no-cache add ca-certificates git
 COPY --from=builder /go/src/github.com/bpineau/katafygio/katafygio /usr/bin/
 USER nobody
 ENTRYPOINT ["/usr/bin/katafygio"]

--- a/assets/Dockerfile.goreleaser
+++ b/assets/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates git
+RUN apk upgrade --no-cache && apk --no-cache add ca-certificates git
 COPY katafygio /usr/bin/
 USER nobody
 ENTRYPOINT ["/usr/bin/katafygio"]


### PR DESCRIPTION
For the sake of security, we should use an updated Alpine image.
Even though we only use "git" from Alpine, Katafygio being
staticaly linked.