### PR TITLE
Don't use tempdir

### DIFF
--- a/cmd/execute_test.go
+++ b/cmd/execute_test.go
@@ -25,6 +25,7 @@ func TestRootCmd(t *testing.T) {
 		"/dev/null",
 		"--dry-run",
 		"--dump-only",
+		"--no-git",
 		"--api-server",
 		"http://192.0.2.1", // RFC 5737 reserved/unroutable
 		"--log-level",

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -157,7 +157,7 @@ func (w *Listener) save(file string, data []byte) error {
 		return fmt.Errorf("can't create local directory %s: %v", dir, err)
 	}
 
-	tmpf, err := afero.TempFile(appFs, "", "katafygio")
+	tmpf, err := afero.TempFile(appFs, dir, ".temp-katafygio-")
 	if err != nil {
 		return fmt.Errorf("failed to create a temporary file: %v", err)
 	}

--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -174,6 +174,11 @@ func (s *Store) CloneOrInit() (err error) {
 			s.Email, s.LocalDir, err)
 	}
 
+	err = afero.WriteFile(appFs, s.LocalDir+"/.git/info/exclude", []byte(".temp-katafygio-*"), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create a git exclusion: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We shouldn't let Afero decide the temporary dir for us, since
this could end up on a different filesystem than the repository,
and rename() don't work cross filesystems.

We don't want to alter .gitignore (which can be edited/managed by
someone else or elsewhere), but we can use the local-only
.git/info/exclude exclusion file (https://git-scm.com/docs/gitignore).

Which allows us to create our temporary files in the repository
itself, and keep everything else (even /tmp) read-only.