### PR TITLE
Explicit volume for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN make build
 
 FROM alpine:3.7
 RUN apk upgrade --no-cache && apk --no-cache add ca-certificates git
+RUN install -d -o nobody -g nobody /var/lib/katafygio/data
 COPY --from=builder /go/src/github.com/bpineau/katafygio/katafygio /usr/bin/
+VOLUME /var/lib/katafygio
 USER nobody
 ENTRYPOINT ["/usr/bin/katafygio"]

--- a/assets/Dockerfile.goreleaser
+++ b/assets/Dockerfile.goreleaser
@@ -1,5 +1,7 @@
 FROM alpine:3.7
 RUN apk upgrade --no-cache && apk --no-cache add ca-certificates git
+RUN install -d -o nobody -g nobody /var/lib/katafygio/data
 COPY katafygio /usr/bin/
+VOLUME /var/lib/katafygio
 USER nobody
 ENTRYPOINT ["/usr/bin/katafygio"]


### PR DESCRIPTION
Creating a /var/lib/katafygio/data dir owned by the container's user,
and declaring the parent dir (/var/lib/katafygio) as a volume, Docker
will copy the (correctly owned) "data" sub-dir at each launch ; which
ensure we can write to this directory. Even when the volume is created
and mounted by Kubernetes.

This image can be used with --local-dir=/var/lib/katafygio/data .