### PR TITLE
Persistence option for the helm chart

### DIFF
--- a/assets/helm-chart/katafygio/Chart.yaml
+++ b/assets/helm-chart/katafygio/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.5.0
+appVersion: 0.6.0
 description: Continuously backup Kubernetes objets as YAML files in git
 name: katafygio
 home: https://github.com/bpineau/katafygio

--- a/assets/helm-chart/katafygio/templates/deployment.yaml
+++ b/assets/helm-chart/katafygio/templates/deployment.yaml
@@ -81,3 +81,11 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    volumes:
+      - name: katafygio-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "katafygio.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/assets/helm-chart/katafygio/templates/pvc.yaml
+++ b/assets/helm-chart/katafygio/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "katafygio.fullname" . }}
+  labels:
+{{ include "katafygio.labels.standard" . | indent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/assets/helm-chart/katafygio/values.yaml
+++ b/assets/helm-chart/katafygio/values.yaml
@@ -2,47 +2,69 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Where we'll dump and commit cluster objects before pushing them to a remote git repository.
-localDir: "/tmp/kf-dump"
-
-# The port we'll listen for health checks requests.
-healthcheckPort: 8080
-
-# Frequency (in seconds) between full catch-up resyncs. 0 to disable.
-resyncInterval: 300
-
-# Logging. Output may be: stdout, stderr, syslog.
-logLevel: warning
-logOutput: stdout
-
-# Optional. Repository where Katafygio would push changes.
+# gitUrl (optional) is a remote git repository that Katafygio can clone, and where 
+# it can push changes. If gitUrl is not defined, Katafygio will still maintain a
+# pod-local git repository, which can be on a persistent volume (see above).
 #gitUrl: https://user:token@github.com/myorg/myrepos.git
 
-# Set to true to disable git versioning.
+# noGit disable git versioning when true (will only keep an unversioned local dump up-to-date).
 noGit: false
 
-# Optional. Label selector to restrict dump to certain objets.
-#filter: "app in (foo, bar)"
+# healthcheckPort is the TCP port Katafygio will listen for health check requests.
+healthcheckPort: 8080
 
-# Optional. Address of a remote syslog server (if logOutput is "syslog").
+# logLevel can be info, warning, error, or fatal.
+logLevel: warning
+# logOutput can be stdout, stderr, or syslog.
+logOutput: stdout
+# logServer (optional) provide the address of a remote syslog server.
 # logServer: "localhost:514"
 
-# Optional. Kubernetes object kinds we want to exclude from the dumps.
+# filter is an (optional) label selector used to restrict backups to selected objects.
+#filter: "app in (foo, bar)"
+
+# excludeKind is an array of excluded (not backuped) Kubernetes objects kinds.
 excludeKind:
   - replicaset
   - endpoints
   - event
 
-# Optional. Specific Kubernetes objets to exclude from the dumps.
+# excludeObject is an array of specific Kubernetes objects to exclude from dumps
+# (the format is: objectkind:namespace/objectname).
 # excludeObject:
 #  - "configmap:kube-system/leader-elector"
 
-# Katafygio needs read-only access to all Kubernetes API groups and resources.
+# resyncInterval is the interval (in seconds) between full catch-up resyncs
+# (to catch possibly missed events). Set to 0 to disable resyncs.
+resyncInterval: 300
+
+# localDir is the path where we'll dump and commit cluster objects.
+localDir: "/var/lib/katafygio/data"
+
+# persistence for the localDir dump directory. Note that configuring gitUrl
+# is an other way to achieve persistence.
+persistence:
+  enabled: true
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  # existingClaim: ""
+
+# rbac allow to enable or disable RBAC role and binding. Katafygio needs
+# read-only access to all Kubernetes API groups and resources.
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
   apiVersion: v1
 
+# serviceAccount is used to provide a dedicated serviceAccount when using RBAC
+# (or to fallback to the namespace's "default" SA if name is left empty).
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
@@ -52,9 +74,13 @@ serviceAccount:
 
 image:
   repository: bpineau/katafygio
-  tag: v0.5.0
+  tag: v0.6.0
   pullPolicy: IfNotPresent
 
+# resources define the deployment's cpu and memory resources.
+# Katafygio only needs about 50Mi of memory as a baseline, and more depending
+# on the cluster's content. For instance, on a 45 nodes cluster with about 2k
+# pods and 1k services, Katafygio use about 250Mi.
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
Per the official guidelines:
https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md
... creating a volume is mandatory, and we should do it by default
(but we still can disable this with "persistence.enabled=false").

While at it, update to the upcoming 0.6.0 release.