### PR TITLE
Fix git local dir on relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ ready to run on your desktop or in a cluster.
 
 We also provide a [docker image](https://hub.docker.com/r/bpineau/katafygio/).
 
+On MacOs, you can use the brew formula:
+```bash
+brew install bpineau/tap/katafygio
+```
+
 You can also deploy with the provided [helm](https://helm.sh/) chart:
 ```shell
 helm install --name kf-backups --namespace kube-system assets/helm-chart/katafygio/

--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/afero"
@@ -145,6 +146,11 @@ func (s *Store) Status() (changed bool, err error) {
 // CloneOrInit create a new local repository, either with "git clone" (if a GitURL
 // to clone from is provided), or "git init" (in the absence of GitURL).
 func (s *Store) CloneOrInit() (err error) {
+	s.LocalDir, err = filepath.Abs(s.LocalDir)
+	if err != nil {
+		return fmt.Errorf("can't find local dir absolute path (broken cwd?): %v", err)
+	}
+
 	if !s.DryRun {
 		err = appFs.MkdirAll(s.LocalDir, 0700)
 		if err != nil {


### PR DESCRIPTION
Since we launched the git command with .Cwd configured to the
target directory, we were creating nested paths when passed
relative --local-dir.

While at it, reference the brew formula.