### PR TITLE
Perform a shallow clone in the git provider for faster startup

### DIFF
--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -161,7 +161,7 @@ func (s *Store) CloneOrInit() (err error) {
 	if s.URL == "" {
 		err = s.Git("init", s.LocalDir)
 	} else {
-		err = s.Git("clone", s.URL, s.LocalDir)
+		err = s.Git("clone", "--depth=1", s.URL, s.LocalDir)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Running katafygio for a couple of months on rather active cluster
results in a huge git repo.

On startup, katafygio clone the git repository, which in our case was
very slow, exceeding the configured deadlines.

This PR propose to perform a shallow clone with a depth of 1: katafygio
doesn't need to full history to work, and the startup is much snappier.