### PR TITLE
Added file diff into commit message

### DIFF
--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -119,9 +119,9 @@ func (s *Store) Git(args ...string) error {
 }
 
 // Status tests the git status of a repository
-func (s *Store) Status() (changed bool, err error, msg string) {
+func (s *Store) Status() (changed bool, msg string, err error) {
 	if s.DryRun {
-		return false, nil, ""
+		return false, "", nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), TimeoutCommands)
@@ -133,14 +133,14 @@ func (s *Store) Status() (changed bool, err error, msg string) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return false, fmt.Errorf("git status failed with code %v: %s", err, out), ""
+		return false, "", fmt.Errorf("git status failed with code %v: %s", err, out)
 	}
 
 	if len(out) != 0 {
-		return true, nil, string(out)
+		return true, string(out), nil
 	}
 
-	return false, nil, ""
+	return false, "", nil
 }
 
 // CloneOrInit create a new local repository, either with "git clone" (if a GitURL
@@ -190,7 +190,7 @@ func (s *Store) CloneOrInit() (err error) {
 
 // Commit git commit all the directory's changes
 func (s *Store) Commit() (changed bool, err error) {
-	changed, err, status := s.Status()
+	changed, status, err := s.Status()
 	if err != nil {
 		return changed, err
 	}

--- a/pkg/store/git/git_test.go
+++ b/pkg/store/git/git_test.go
@@ -36,7 +36,7 @@ func TestGitDryRun(t *testing.T) {
 		t.Errorf("failed to start git: %v", err)
 	}
 
-	_, err = repo.Status()
+	_, _, err = repo.Status()
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,15 +63,15 @@ func TestGit(t *testing.T) {
 		t.Errorf("failed to start git: %v", err)
 	}
 
-	changed, err := repo.Status()
-	if changed || err != nil {
+	changed, status, err := repo.Status()
+	if changed || status != "" || err != nil {
 		t.Errorf("Status should return false on empty new repos (%v)", err)
 	}
 
 	_ = ioutil.WriteFile(dir+"/t.yaml", []byte{42}, 0600)
 
-	changed, err = repo.Status()
-	if !changed || err != nil {
+	changed, status, err = repo.Status()
+	if !changed || status == "" || err != nil {
 		t.Errorf("Status should return true on non committed files (%v)", err)
 	}
 
@@ -80,8 +80,8 @@ func TestGit(t *testing.T) {
 		t.Errorf("Commit should notify changes and not fail (%v)", err)
 	}
 
-	changed, err = repo.Status()
-	if changed || err != nil {
+	changed, status, err = repo.Status()
+	if changed || status != "" || err != nil {
 		t.Errorf("Status should return false after a add+commit (%v)", err)
 	}
 
@@ -110,8 +110,8 @@ func TestGit(t *testing.T) {
 	_ = ioutil.WriteFile(newdir+"/t2.yaml", []byte{42}, 0600)
 	repo.commitAndPush()
 
-	changed, err = repo.Status()
-	if changed || err != nil {
+	changed, status, err = repo.Status()
+	if changed || status != "" || err != nil {
 		t.Errorf("Status should return false after a add+commit+push (%v)", err)
 	}
 
@@ -141,7 +141,7 @@ func TestGit(t *testing.T) {
 	defer os.RemoveAll(notrepo)
 
 	repo.LocalDir = notrepo
-	_, err = repo.Status()
+	_, _, err = repo.Status()
 	if err == nil {
 		t.Error("Status should fail on a non-repos")
 	}


### PR DESCRIPTION
Added list of modified files into each commit message. Reused output of `git status --porcelain`.

Current log messages now looks like this:
```
commit 16c88f652928535e9d5a68750de4cfe746489335
Author: Katafygio <katafygio@localhost>
Date:   Fri Feb 1 07:31:20 2019 +0000

    Kubernetes cluster change
    
     M tech/configmap-gitlab-runner-cm.yaml
     M tech/deployment-gitlab-runner.yaml
```

Please review and possibly refactor my changes. I am not golang developer.