### PR TITLE
Configurable git commands deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Flags:
   -x, --exclude-kind strings     Ressource kind to exclude. Eg. 'deployment'
   -y, --exclude-object strings   Object to exclude. Eg. 'configmap:kube-system/kube-dns'
   -l, --filter string            Label filter. Select only objects matching the label
+  -t, --git-timeout duration     Git operations timeout (default 5m0s)
   -g, --git-url string           Git repository URL
   -p, --healthcheck-port int     Port for answering healthchecks on /health url
   -h, --help                     help for katafygio

--- a/assets/helm-chart/katafygio/templates/deployment.yaml
+++ b/assets/helm-chart/katafygio/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
           args:
             - --local-dir={{ .Values.localDir }}
             - --healthcheck-port={{ .Values.healthcheckPort }}
+          {{- if .Values.gitTimeout }}
+            - --git-timeout={{ .Values.gitTimeout }}
+          {{- end }}
           {{- if .Values.gitUrl }}
             - --git-url={{ .Values.gitUrl }}
           {{- end }}

--- a/assets/helm-chart/katafygio/values.yaml
+++ b/assets/helm-chart/katafygio/values.yaml
@@ -7,6 +7,10 @@
 # pod-local git repository, which can be on a persistent volume (see above).
 #gitUrl: https://user:token@github.com/myorg/myrepos.git
 
+# gitTimeout (optional) defines the deadline for git commands
+# (available with Katafygio v0.7.4 and up).
+#gitTimeout: 300s
+
 # noGit disable git versioning when true (will only keep an unversioned local dump up-to-date).
 noGit: false
 

--- a/assets/katafygio.yaml
+++ b/assets/katafygio.yaml
@@ -14,6 +14,9 @@ local-dir: /var/cache/katafygio
 # Remote url is optional. If provided, Katafygio will push there.
 #git-url: https://user:token@github.com/myorg/myrepos.git
 
+# Git timeout is the deadline for git commands
+#git-timeout: 300s
+
 # Port to listen for http health check probes. 0 to disable.
 healthcheck-port: 0
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -2,28 +2,30 @@ package cmd
 
 import (
 	"log"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var (
-	cfgFile   string
-	apiServer string
-	kubeConf  string
-	dryRun    bool
-	dumpMode  bool
-	logLevel  string
-	logOutput string
-	logServer string
-	filter    string
-	localDir  string
-	gitURL    string
-	healthP   int
-	resyncInt int
-	exclkind  []string
-	exclobj   []string
-	noGit     bool
+	cfgFile    string
+	apiServer  string
+	kubeConf   string
+	dryRun     bool
+	dumpMode   bool
+	logLevel   string
+	logOutput  string
+	logServer  string
+	filter     string
+	localDir   string
+	gitURL     string
+	gitTimeout time.Duration
+	healthP    int
+	resyncInt  int
+	exclkind   []string
+	exclobj    []string
+	noGit      bool
 )
 
 func bindPFlag(key string, cmd string) {
@@ -69,6 +71,9 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&gitURL, "git-url", "g", "", "Git repository URL")
 	bindPFlag("git-url", "git-url")
 
+	RootCmd.PersistentFlags().DurationVarP(&gitTimeout, "git-timeout", "t", 300*time.Second, "Git operations timeout")
+	bindPFlag("git-timeout", "git-timeout")
+
 	RootCmd.PersistentFlags().StringSliceVarP(&exclkind, "exclude-kind", "x", nil, "Ressource kind to exclude. Eg. 'deployment'")
 	bindPFlag("exclude-kind", "exclude-kind")
 
@@ -100,6 +105,7 @@ func bindConf(cmd *cobra.Command, args []string) {
 	filter = viper.GetString("filter")
 	localDir = viper.GetString("local-dir")
 	gitURL = viper.GetString("git-url")
+	gitTimeout = viper.GetDuration("git-timeout")
 	healthP = viper.GetInt("healthcheck-port")
 	resyncInt = viper.GetInt("resync-interval")
 	exclkind = viper.GetStringSlice("exclude-kind")

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func ExitWrapper(exit int) {
 func main() {
 	err := cmd.Execute()
 	if err != nil {
-		fmt.Printf("%+v", err)
+		fmt.Printf("%+v\n", err)
 		ExitWrapper(1)
 	}
 }

--- a/pkg/store/git/git_test.go
+++ b/pkg/store/git/git_test.go
@@ -5,11 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 )
 
-var testHasGit bool
+var (
+	testHasGit bool
+	timeout    = 5 * time.Second
+)
 
 func init() {
 	// Thanks to Mitchell Hashimoto!
@@ -31,7 +35,7 @@ func TestGitDryRun(t *testing.T) {
 
 	appFs = afero.NewMemMapFs()
 
-	repo, err := New(new(mockLog), true, "/tmp/ktest", "").Start()
+	repo, err := New(new(mockLog), true, "/tmp/ktest", "", timeout).Start()
 	if err != nil {
 		t.Errorf("failed to start git: %v", err)
 	}
@@ -58,7 +62,7 @@ func TestGit(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 
-	repo, err := New(new(mockLog), false, dir, "").Start()
+	repo, err := New(new(mockLog), false, dir, "", timeout).Start()
 	if err != nil {
 		t.Errorf("failed to start git: %v", err)
 	}


### PR DESCRIPTION
* Start logging early, so we can see whether the application started
* Expose the git commands timeout as a command line flags (and sets generous defaults)
* Don't display --help/usage info with hard failures error messages
* Don't wait for git clone to succeed before hooking health probes listener: it was configured to fail probes early, when the initial clone was failing; but an app logging an error message before exiting makes diagnostics easier than kubelet probes failures.

Closes #81 