### PR TITLE
Update to latest goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ builds:
     ldflags: -s -w -X github.com/bpineau/katafygio/cmd.version={{.Version}}
     env:
       - CGO_ENABLED=0
+      - GO111MODULE=on
     goos:
       - darwin
       - linux
@@ -15,6 +16,10 @@ builds:
     hooks:
       post: make man
 
+before:
+  hooks:
+  - go mod download
+
 release:
   # don't autopublish
   draft: true
@@ -22,7 +27,8 @@ release:
 sign:
   artifacts: checksum
 
-archive:
+archives:
+- id: katafygio
   format: binary
 
 changelog:
@@ -31,15 +37,16 @@ changelog:
       - Merge
 
 dockers:
-  - image: bpineau/katafygio
+  - image_templates:
+    - "bpineau/katafygio:latest"
+    - "bpineau/katafygio:{{ .Tag }}"
     goos: linux
     goarch: amd64
     dockerfile: assets/Dockerfile.goreleaser
-    tag_templates:
-      - '{{ .Tag }}'
-      - latest
+    skip_push: true
 
-nfpm:
+nfpms:
+-
   name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
   homepage: https://github.com/bpineau/katafygio
   description: Discover and continuously backup Kubernetes objets as yaml files in git

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -127,6 +128,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=


### PR DESCRIPTION
Fix deprecated directives, adjust for go mod.
We're at goreleaser 0.112.2.