### PR TITLE
Container run user changed from name to numeric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ RUN apk upgrade --no-cache && \
 RUN install -d -o nobody -g nobody /var/lib/katafygio/data
 COPY --from=builder /go/src/github.com/bpineau/katafygio/katafygio /usr/bin/
 VOLUME /var/lib/katafygio
-USER nobody
+USER 65534
 ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/katafygio"]


### PR DESCRIPTION
When Kubernetes security policy runAsNonRoot is used it requires containers to be run as user explicitly by numeric ID.

When user name is used it refuses to run container with following error:
```
Error: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root
```
