### PR TITLE
Support provided contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ will help to keep resources usage low, and a concise git history. Eg.:
 # confidential), events and node (irrelevant), and the leader-elector
 # configmap that has low value and changes a lot, causing commits churn.
 
-katafygio \
-  -g https://user:token@github.com/myorg/myrepos.git -e /tmp/kfdump \
-  -x secret -x pod -x replicaset -x node -x endpoints -x event \
+katafygio -e /tmp/kfdump \
+  -g https://user:token@github.com/myorg/myrepos.git \
+  -x secret,pod,event,replicaset,node,endpoints \
   -y configmap:kube-system/leader-elector
 ```
 
@@ -60,6 +60,7 @@ Available Commands:
 Flags:
   -s, --api-server string        Kubernetes api-server url
   -c, --config string            Configuration file (default "/etc/katafygio/katafygio.yaml")
+  -q, --context string           Kubernetes configuration context
   -d, --dry-run                  Dry-run mode: don't store anything
   -m, --dump-only                Dump mode: dump everything once and exit
   -x, --exclude-kind strings     Ressource kind to exclude. Eg. 'deployment'

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -47,7 +47,7 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 	logger.Info(appName, " starting")
 
 	if restcfg == nil {
-		restcfg, err = client.New(apiServer, kubeConf)
+		restcfg, err = client.New(apiServer, context, kubeConf)
 		if err != nil {
 			return fmt.Errorf("failed to create a client: %v", err)
 		}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -11,6 +11,7 @@ import (
 var (
 	cfgFile    string
 	apiServer  string
+	context    string
 	kubeConf   string
 	dryRun     bool
 	dumpMode   bool
@@ -44,7 +45,10 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&apiServer, "api-server", "s", "", "Kubernetes api-server url")
 	bindPFlag("api-server", "api-server")
 
-	RootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "Kubernetes config path")
+	RootCmd.PersistentFlags().StringVarP(&context, "context", "q", "", "Kubernetes configuration context")
+	bindPFlag("context", "context")
+
+	RootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "Kubernetes configuration path")
 	bindPFlag("kube-config", "kube-config")
 	if err := viper.BindEnv("kube-config", "KUBECONFIG"); err != nil {
 		log.Fatal("Failed to bind cli argument:", err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,12 +3,10 @@ package client
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	// Ensure we have auth plugins (gcp, azure, openstack, ...) linked in
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -25,48 +23,28 @@ type RestClient struct {
 }
 
 // New create a new RestClient
-func New(apiserver, kubeconfig string) (*RestClient, error) {
-	cfg, err := newRestConfig(apiserver, kubeconfig)
+func New(apiserver, context, kubeconfig string) (*RestClient, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfig
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		&clientcmd.ConfigOverrides{
+			ClusterInfo:    clientcmdapi.Cluster{Server: apiserver},
+			CurrentContext: context,
+		},
+	)
+
+	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build a restconfig: %v", err)
 	}
 
 	return &RestClient{
-		cfg: cfg,
+		cfg: restConfig,
 	}, nil
 }
 
 // GetRestConfig returns the current rest.Config
 func (r *RestClient) GetRestConfig() *rest.Config {
 	return r.cfg
-}
-
-// newRestConfig create a *rest.Config, trying to mimic kubectl behavior:
-// - Explicit user provided api-server (and/or kubeconfig path) have higher priorities
-// - Else, use the config file path in KUBECONFIG environment variable (if any)
-// - Else, use the config file in ~/.kube/config, if any
-// - Else, consider we're running in cluster (in a pod), and use the pod's service
-//   account and cluster's kubernetes.default service.
-func newRestConfig(apiserver string, kubeconfig string) (*rest.Config, error) {
-	// if not passed as an argument, kubeconfig can be provided as env var
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	}
-
-	// if we're not provided an explicit kubeconfig path (via env, or argument),
-	// try to find one at the standard place (in user's home/.kube/config).
-	homeCfg := filepath.Join(homedir.HomeDir(), ".kube", "config")
-	_, err := os.Stat(homeCfg)
-	if kubeconfig == "" && err == nil {
-		kubeconfig = homeCfg
-	}
-
-	// if we were provided or found a kubeconfig,
-	// or if we were provided an api-server url, use that
-	if apiserver != "" || kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-	}
-
-	// else assume we're running in a pod, in cluster
-	return rest.InClusterConfig()
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -11,7 +11,7 @@ const nonExistentPath = "\\/non / existent / $path$"
 func TestClientSet(t *testing.T) {
 	here, _ := os.Getwd()
 	_ = os.Setenv("HOME", here+"/../../assets")
-	cs, err := New("", "")
+	cs, err := New("", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,12 +19,12 @@ func TestClientSet(t *testing.T) {
 		t.Errorf("GetRestConfig() didn't return a *rest.Config: %T", cs)
 	}
 
-	cs, _ = New("http://127.0.0.1", "/dev/null")
+	cs, _ = New("http://127.0.0.1", "", "/dev/null")
 	if fmt.Sprintf("%T", cs.GetRestConfig()) != "*rest.Config" {
 		t.Errorf("New(server) didn't return a *rest.Config: %T", cs)
 	}
 
-	_, err = New("http://127.0.0.1", nonExistentPath)
+	_, err = New("http://127.0.0.1", "", nonExistentPath)
 	if err == nil {
 		t.Fatal("New() should fail on non existent kubeconfig path")
 	}
@@ -32,7 +32,7 @@ func TestClientSet(t *testing.T) {
 	_ = os.Unsetenv("KUBERNETES_SERVICE_HOST")
 	_ = os.Setenv("HOME", nonExistentPath)
 	_ = os.Setenv("KUBECONFIG", nonExistentPath)
-	_, err = New("", "")
+	_, err = New("", "", "")
 	if err == nil {
 		t.Fatal("New() should fail to load InClusterConfig without kube address env")
 	}


### PR DESCRIPTION
Allow users to provide an explicit k8s context.
While at it, rely on clientcmd provided code to load the configuration.