### PR TITLE
Support singular and short resources names in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ will help to keep resources usage low, and a concise git history. Eg.:
 
 katafygio -e /tmp/kfdump \
   -g https://user:token@github.com/myorg/myrepos.git \
-  -x secret,pod,event,replicaset,node,endpoints \
+  -x secret,pod,event,replicaset,node,endpoint \
   -y configmap:kube-system/leader-elector
 ```
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -185,7 +185,7 @@ func (c *Observer) expandAndFilterAPIResources(groups []*metav1.APIResourceList)
 			}
 
 			// remove user filtered objet kinds
-			if isExcluded(c.excludedkind, ar.Kind) {
+			if isExcluded(c.excludedkind, ar) {
 				continue
 			}
 
@@ -210,11 +210,25 @@ func (c *Observer) expandAndFilterAPIResources(groups []*metav1.APIResourceList)
 	return resources
 }
 
-func isExcluded(excluded []string, name string) bool {
-	lname := strings.ToLower(name)
+func isExcluded(excluded []string, ar metav1.APIResource) bool {
+	lname := strings.ToLower(ar.Name)
+	singular := strings.ToLower(ar.SingularName)
+
 	for _, ctl := range excluded {
-		if strings.Compare(lname, strings.ToLower(ctl)) == 0 {
+		excl := strings.ToLower(ctl)
+
+		if strings.Compare(lname, excl) == 0 {
 			return true
+		}
+
+		if strings.Compare(singular, excl) == 0 {
+			return true
+		}
+
+		for _, alt := range ar.ShortNames {
+			if strings.Compare(strings.ToLower(alt), excl) == 0 {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
So a given k8s resources can be filter by it's name (plural,
eg. "enpoints"), it's singular ("endpoint") or one of it's
short names (eg. "ep", "deploy", "po"...).