### PR TITLE
Update doc, eg config file and filter on kind too

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To create a local git repository and continuously save the cluster content:
 katafygio --local-dir /tmp/kfdump
 ```
 
-Same, but also continuously push to a remote repository:
+To continuously push changes to a remote git repository:
 ```bash
 katafygio --git-url https://user:token@github.com/myorg/myrepos.git --local-dir /tmp/kfdump
 ```
@@ -47,7 +47,8 @@ You can also use the [docker image](https://hub.docker.com/r/bpineau/katafygio/)
 
 ```
 Backup Kubernetes cluster as yaml files in a git repository.
---exclude-kind (-x) and --exclude-object (-y) may be specified several times.
+--exclude-kind (-x) and --exclude-object (-y) may be specified several times,
+or once with several comma separated values.
 
 Usage:
   katafygio [flags]
@@ -70,7 +71,7 @@ Flags:
   -g, --git-url string           Git repository URL
   -p, --healthcheck-port int     Port for answering healthchecks on /health url
   -h, --help                     help for katafygio
-  -k, --kube-config string       Kubernetes config path
+  -k, --kube-config string       Kubernetes configuration path
   -e, --local-dir string         Where to dump yaml files (default "./kubernetes-backup")
   -v, --log-level string         Log level (default "info")
   -o, --log-output string        Log output (default "stderr")
@@ -79,7 +80,7 @@ Flags:
   -i, --resync-interval int      Full resync interval in seconds (0 to disable) (default 900)
 ```
 
-## Config file and env variables
+## Configuration file and env variables
 
 All settings can be passed by command line options, or environment variable, or in
 [a yaml configuration file](https://github.com/bpineau/katafygio/blob/master/assets/katafygio.yaml)
@@ -90,8 +91,9 @@ in uppercase, prefixed by "KF", and with underscore instead of dashs. ie.:
 export KF_GIT_URL=https://user:token@github.com/myorg/myrepos.git
 export KF_LOCAL_DIR=/tmp/kfdump
 export KF_LOG_LEVEL=info
+export KF_EXCLUDE_KIND="pod ep rs clusterrole"
 
-# exception, for kubectl compatibility:
+# non-prefixed KUBECONFIG works the same as for kubectl
 export KUBECONFIG=/tmp/kconfig
 ```
 

--- a/assets/katafygio.yaml
+++ b/assets/katafygio.yaml
@@ -3,6 +3,7 @@
 # To provide alternate api-server URL or config to reach the cluster:
 #api-server: http://127.0.0.1:8080
 #kube-config: /etc/kubernetes/config
+#context: default
 
 log-level: "info"
 log-output: "stderr"
@@ -18,7 +19,7 @@ local-dir: /var/cache/katafygio
 #git-timeout: 300s
 
 # Port to listen for http health check probes. 0 to disable.
-healthcheck-port: 0
+healthcheck-port: 8080
 
 # How often should Katafygio full resync. Only needed to catch possibly
 # missed events: events are handled in real-time. 0 to disable.
@@ -44,3 +45,11 @@ resync-interval: 900
 #  - configmap:kube-system/datadog-leader-elector
 #  - deployment:default/testdeploy
 
+# Set to true o dump once and exit (instead of continuously dumping new changes)
+dump-only: false
+
+# Set to true to disable git versionning
+no-git: false
+
+# Set to true to simulate operations (not dumping or versionning anything)
+dry-run: false

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -50,9 +50,6 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "Kubernetes configuration path")
 	bindPFlag("kube-config", "kube-config")
-	if err := viper.BindEnv("kube-config", "KUBECONFIG"); err != nil {
-		log.Fatal("Failed to bind cli argument:", err)
-	}
 
 	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Dry-run mode: don't store anything")
 	bindPFlag("dry-run", "dry-run")
@@ -100,6 +97,7 @@ func init() {
 // for whatever the reason, viper don't auto bind values from config file so we have to tell him
 func bindConf(cmd *cobra.Command, args []string) {
 	apiServer = viper.GetString("api-server")
+	context = viper.GetString("context")
 	kubeConf = viper.GetString("kube-config")
 	dryRun = viper.GetBool("dry-run")
 	dumpMode = viper.GetBool("dump-only")

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -212,12 +212,17 @@ func (c *Observer) expandAndFilterAPIResources(groups []*metav1.APIResourceList)
 
 func isExcluded(excluded []string, ar metav1.APIResource) bool {
 	lname := strings.ToLower(ar.Name)
+	lkind := strings.ToLower(ar.Kind)
 	singular := strings.ToLower(ar.SingularName)
 
 	for _, ctl := range excluded {
 		excl := strings.ToLower(ctl)
 
 		if strings.Compare(lname, excl) == 0 {
+			return true
+		}
+
+		if strings.Compare(lkind, excl) == 0 {
 			return true
 		}
 

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -264,7 +264,7 @@ func TestObserverRecoverFromDicoveryFailure(t *testing.T) {
 }
 
 func TestExclusion(t *testing.T) {
-	excluded := []string{"rs", "poD", "endpoints"} // short, singular, plural forms
+	excluded := []string{"rs", "pods", "node", "Endpoint"} // short, singular, plural forms
 
 	if isExcluded(excluded,
 		metav1.APIResource{Name: "Foos", Kind: "Foo", SingularName: "Foo", ShortNames: []string{}}) {
@@ -277,7 +277,12 @@ func TestExclusion(t *testing.T) {
 	}
 
 	if !isExcluded(excluded,
-		metav1.APIResource{Name: "Pods", Kind: "Pod", SingularName: "Pod", ShortNames: []string{"po"}}) {
+		metav1.APIResource{Name: "Pods", Kind: "Pod", ShortNames: []string{"po"}}) {
+		t.Error("exclusions should consider kind's name")
+	}
+
+	if !isExcluded(excluded,
+		metav1.APIResource{Name: "Node", Kind: "Node", SingularName: "Node", ShortNames: []string{""}}) {
 		t.Error("exclusions should ignore objects case")
 	}
 


### PR DESCRIPTION
* Viper way to pass slices (arrays) through env isn't obvious, let's provide an example
* Update the example configuration file to reflect available options
* Some resources defs don't have a singular form, outside of the Kind name