### PR TITLE
Ensure .git/info directory exists before writing to it

### DIFF
--- a/pkg/store/git/git.go
+++ b/pkg/store/git/git.go
@@ -190,6 +190,11 @@ func (s *Store) CloneOrInit() (err error) {
 			s.Email, s.LocalDir, err)
 	}
 
+	err = appFs.MkdirAll(s.LocalDir+"/.git/info", 0744)
+	if err != nil {
+		return fmt.Errorf("failed to create git info directory: %v", err)
+	}
+
 	err = afero.WriteFile(appFs, s.LocalDir+"/.git/info/exclude", []byte(".temp-katafygio-*"), 0644)
 	if err != nil {
 		return fmt.Errorf("failed to create a git exclusion: %v", err)


### PR DESCRIPTION
When testing from the command line I was getting "failed to create a git exclusion" as the .git/info directory didn't exist. This is a tiny patch to remedy that.