### PR TITLE
Exclude namespaces by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,26 +59,27 @@ Available Commands:
   version     Print the version number
 
 Flags:
-  -s, --api-server string        Kubernetes api-server url
-  -c, --config string            Configuration file (default "/etc/katafygio/katafygio.yaml")
-  -q, --context string           Kubernetes configuration context
-  -d, --dry-run                  Dry-run mode: don't store anything
-  -m, --dump-only                Dump mode: dump everything once and exit
-  -x, --exclude-kind strings     Ressource kind to exclude. Eg. 'deployment'
-  -y, --exclude-object strings   Object to exclude. Eg. 'configmap:kube-system/kube-dns'
-  -l, --filter string            Label filter. Select only objects matching the label
-  -t, --git-timeout duration     Git operations timeout (default 5m0s)
-  -g, --git-url string           Git repository URL
-  -p, --healthcheck-port int     Port for answering healthchecks on /health url
-  -h, --help                     help for katafygio
-  -k, --kube-config string       Kubernetes configuration path
-  -e, --local-dir string         Where to dump yaml files (default "./kubernetes-backup")
-  -v, --log-level string         Log level (default "info")
-  -o, --log-output string        Log output (default "stderr")
-  -r, --log-server string        Log server (if using syslog)
-  -a, --namespace string         Only dump objects from this namespace
-  -n, --no-git                   Don't version with git
-  -i, --resync-interval int      Full resync interval in seconds (0 to disable) (default 900)
+  -s, --api-server string            Kubernetes api-server url
+  -c, --config string                Configuration file (default "/etc/katafygio/katafygio.yaml")
+  -q, --context string               Kubernetes configuration context
+  -d, --dry-run                      Dry-run mode: don't store anything
+  -m, --dump-only                    Dump mode: dump everything once and exit
+  -x, --exclude-kind strings         Ressource kind to exclude. Eg. 'deployment'
+  -z, --exclude-namespaces strings   Namespaces to exclude. Eg. 'temp.*' as regexes. This collects all namespaces and then filters them. Don't use it with the namespace flag.
+  -y, --exclude-object strings       Object to exclude. Eg. 'configmap:kube-system/kube-dns'
+  -l, --filter string                Label filter. Select only objects matching the label
+  -t, --git-timeout duration         Git operations timeout (default 5m0s)
+  -g, --git-url string               Git repository URL
+  -p, --healthcheck-port int         Port for answering healthchecks on /health url
+  -h, --help                         help for katafygio
+  -k, --kube-config string           Kubernetes configuration path
+  -e, --local-dir string             Where to dump yaml files (default "./kubernetes-backup")
+  -v, --log-level string             Log level (default "info")
+  -o, --log-output string            Log output (default "stderr")
+  -r, --log-server string            Log server (if using syslog)
+  -a, --namespace string             Only dump objects from this namespace
+  -n, --no-git                       Don't version with git
+  -i, --resync-interval int          Full resync interval in seconds (0 to disable) (default 900)
 ```
 
 ## Configuration file and env variables

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -70,7 +70,7 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	evts := event.New()
-	fact := controller.NewFactory(logger, filter, resyncInt, exclobj)
+	fact := controller.NewFactory(logger, filter, resyncInt, exclobj, exclnamespaces)
 	reco := recorder.New(logger, evts, localDir, resyncInt*2, dryRun).Start()
 	obsv := observer.New(logger, restcfg, evts, fact, exclkind, namespace).Start()
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,25 +9,26 @@ import (
 )
 
 var (
-	cfgFile    string
-	apiServer  string
-	context    string
-	namespace  string
-	kubeConf   string
-	dryRun     bool
-	dumpMode   bool
-	logLevel   string
-	logOutput  string
-	logServer  string
-	filter     string
-	localDir   string
-	gitURL     string
-	gitTimeout time.Duration
-	healthP    int
-	resyncInt  int
-	exclkind   []string
-	exclobj    []string
-	noGit      bool
+	cfgFile        string
+	apiServer      string
+	context        string
+	namespace      string
+	exclnamespaces []string
+	kubeConf       string
+	dryRun         bool
+	dumpMode       bool
+	logLevel       string
+	logOutput      string
+	logServer      string
+	filter         string
+	localDir       string
+	gitURL         string
+	gitTimeout     time.Duration
+	healthP        int
+	resyncInt      int
+	exclkind       []string
+	exclobj        []string
+	noGit          bool
 )
 
 func bindPFlag(key string, cmd string) {
@@ -51,6 +52,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "a", "", "Only dump objects from this namespace")
 	bindPFlag("namespace", "namespace")
+
+	RootCmd.PersistentFlags().StringSliceVarP(&exclnamespaces, "exclude-namespaces", "z", nil, "Namespaces to exclude. Eg. 'temp.*' as regexes. This collects all namespaces and then filters them. Don't use it with the namespace flag.")
+	bindPFlag("exclude-namespaces", "exclude-namespaces")
 
 	RootCmd.PersistentFlags().StringVarP(&kubeConf, "kube-config", "k", "", "Kubernetes configuration path")
 	bindPFlag("kube-config", "kube-config")
@@ -103,6 +107,7 @@ func bindConf(cmd *cobra.Command, args []string) {
 	apiServer = viper.GetString("api-server")
 	context = viper.GetString("context")
 	namespace = viper.GetString("namespace")
+	exclnamespaces = viper.GetStringSlice("exclude-namespaces")
 	kubeConf = viper.GetString("kube-config")
 	dryRun = viper.GetBool("dry-run")
 	dumpMode = viper.GetBool("dump-only")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -121,7 +121,7 @@ func TestController(t *testing.T) {
 
 	evt := new(mockNotifier)
 	log := new(mockLog)
-	f := NewFactory(log, "label1=something", 60, []string{"pod:ns3/Bar3"})
+	f := NewFactory(log, "label1=something", 60, []string{"pod:ns3/Bar3"}, []string{})
 	ctrl := f.NewController(client, evt, "pod")
 
 	// this will trigger a deletion event


### PR DESCRIPTION
Feature to exclude namespaces.

Takes one or more regular expressions, and objects in those namespaces will not be saved. The background sweep will delete them if they previously had been captured by katafygio.

This allows me to avoid saving away our jenkins workloads by using "jenkins.*" to exclude.

Does not make sense to use this flag with the namespace option (which can only take a single namespace), but it's not explicitly disallowed.