### PR TITLE
Include ingress resource in preferred versions list

### DIFF
--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -171,6 +171,7 @@ var preferredVersions = map[string]string{
 	"events:events":                     ":events",
 	"extensions:podsecuritypolicies":    "policy:podsecuritypolicies",
 	"networking.k8s.io:networkpolicies": "extensions:networkpolicies",
+	"networking.k8s.io:ingress":         "extensions:ingress",
 }
 
 func (c *Observer) expandAndFilterAPIResources(groups []*metav1.APIResourceList) resources {


### PR DESCRIPTION
Since several versions of Kubernetes, the ingress resource has been
assigned to the API group `networking.k8s.io`, but still compatible
with the group `extensions`. This cohabitation brings a weird behavior
to Katafygio, where every 30 minutes, the API group would switch from
the group `extensions` and `networking.k8s.io`.

To avoid that, Katafygio should ignore the old API group and use only
the new one.