### PR TITLE
Linter fixes and go version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.13.x"
+  - "1.15.x"
 
 # needed for e2e tests (so we can start minikube)
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 WORKDIR /go/src/github.com/bpineau/katafygio
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=1.21.0
+GOLANGCI_VERSION=1.33.0
 export GO111MODULE := on
 
 all: build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bpineau/katafygio
 
-go 1.13
+go 1.15
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,7 +28,7 @@ import (
 var (
 	maxProcessRetry = 6
 	canaryKey       = "$katafygio canary$"
-	unexported      = []string{"selfLink", "uid", "resourceVersion", "generation"}
+	unexported      = []string{"selfLink", "uid", "resourceVersion", "generation", "managedFields"}
 )
 
 // Interface describe a standard kubernetes controller
@@ -77,7 +77,7 @@ func New(client cache.ListerWatcher,
 	excludednamespace []string,
 ) *Controller {
 
-	selector := metav1.ListOptions{LabelSelector: filter, ResourceVersion: "0"}
+	selector := metav1.ListOptions{LabelSelector: filter, ResourceVersion: "0", AllowWatchBookmarks: true}
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.List(selector)
@@ -234,7 +234,7 @@ func (c *Controller) processItem(key string) error {
 		for _, nsre := range c.excludedns {
 			if nsre.MatchString(namespace) {
 				// Rely on the background sync to delete these excluded files if
-				// we previously had aquired them
+				// we previously had acquired them
 				return nil
 			}
 		}


### PR DESCRIPTION
Small changes:
* Upgrade to latest go and golint version, to ease development
* Explicitely ask for watch bookmarks where possible
* Filter out `managedFields` (k8s 1.19 noise) as this severely bloat archives, and has little value being backuped

Not sure if we should keep the `mispell` linter (which just broke
travis tests on master), as they are of low value.