### PR TITLE
Update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,9 +24,6 @@ release:
   # don't autopublish
   draft: true
 
-sign:
-  artifacts: checksum
-
 archives:
 - id: katafygio
   format: binary
@@ -47,7 +44,7 @@ dockers:
 
 nfpms:
 -
-  name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
+  file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
   homepage: https://github.com/bpineau/katafygio
   description: Discover and continuously backup Kubernetes objets as yaml files in git
   maintainer: Benjamin Pineau <ben.pineau@gmail.com>
@@ -68,8 +65,8 @@ nfpms:
       replacements:
         amd64: x86_64
         386: i686
-      name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+      file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     deb:
       replacements:
         386: i386
-      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+      file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/bpineau/katafygio
 COPY . .
 RUN make build
 
-FROM alpine:3.10
+FROM alpine:3.12
 RUN apk upgrade --no-cache && \
     apk --no-cache add ca-certificates git openssh-client tini
 RUN install -d -o nobody -g nobody /var/lib/katafygio/data

--- a/assets/Dockerfile.goreleaser
+++ b/assets/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 RUN apk upgrade --no-cache && \
     apk --no-cache add ca-certificates git openssh-client tini
 RUN install -d -o nobody -g nobody /var/lib/katafygio/data

--- a/assets/e2e_test.go
+++ b/assets/e2e_test.go
@@ -34,7 +34,7 @@ type dumpStep struct {
 
 var testsTable = []dumpStep{
 	{"kubectl create ns kf-e2e-test-1", "kubectl delete ns kf-e2e-test-1", "namespace-kf-e2e-test-1.yaml", true},
-	{"kubectl run kf-e2e-test-2 --image=gcr.io/google_containers/pause-amd64:3.0", "kubectl delete deploy kf-e2e-test-2", "default/deployment-kf-e2e-test-2.yaml", true},
+	{"kubectl create deployment kf-e2e-test-2 --image=gcr.io/google_containers/pause-amd64:3.0", "kubectl delete deploy kf-e2e-test-2", "default/deployment-kf-e2e-test-2.yaml", true},
 	{"kubectl expose deployment kf-e2e-test-2 --port=80 --target-port=8000 --name=kf-e2e-test-3", "kubectl delete svc kf-e2e-test-3", "default/service-kf-e2e-test-3.yaml", true},
 	{"kubectl delete service kf-e2e-test-3", "", "default/service-kf-e2e-test-3.yaml", false},
 	{"kubectl delete namespace kf-e2e-test-1", "", "namespace-kf-e2e-test-1.yaml", false},


### PR DESCRIPTION
Update the `.goreleaser.yml` file to support latest/current goreleaser
version (v0.148.0 as of today), in preparation for a switch from Travis
over Github Actions.

While at it, also update e2e tests to create the test deployment using
`create deployment`, since `kubectl run` create unmanaged pods with
recent kubectl versions.