### PR TITLE
Use proper labels selector terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ katafygio --no-git --dump-only --local-dir /tmp/clusterdump/
 
 To create a local git repository and continuously save the cluster content:
 ```bash
-katafygio --local-dir /tmp/kfdump
+katafygio --local-dir /tmp/clusterdump/
 ```
 
 To continuously push changes to a remote git repository:
 ```bash
-katafygio --git-url https://user:token@github.com/myorg/myrepos.git --local-dir /tmp/kfdump
+katafygio --git-url https://user:token@github.com/myorg/myrepos.git --local-dir /tmp/clusterdump/
 ```
 
 Filtering out irrelevant objects (esp. ReplicaSets and Pods) with `-w`, `-x`, `-y`
@@ -31,15 +31,16 @@ and `-z` is useful to keep a concise git history.
 ```bash
 # Filtering out objects having an owner reference (eg. managed pods or replicasets,
 # from Deployments, Daemonsets etc that we already archive), secrets (confidential),
-# events and nodes (irrelevant), and a configmap named "leader-elector" that has
-# low value and is causing commits churn:
+# events and nodes (irrelevant), helm secrets/configmap releases, and a configmap
+# named "leader-elector" that has low value and is causing commits churn:
 
 katafygio \
-  --local-dir /tmp/kfdump \
+  --local-dir /tmp/clusterdump/ \
   --git-url https://user:token@github.com/myorg/myrepos.git \
   --exclude-having-owner-ref \
   --exclude-kind secrets,events,nodes,endpoints \
-  --exclude-object configmap:kube-system/leader-elector
+  --exclude-object configmap:kube-system/leader-elector \
+  --filter 'owner!=helm'
 ```
 
 You can also use the [docker image](https://hub.docker.com/r/bpineau/katafygio/).
@@ -69,7 +70,7 @@ Flags:
   -x, --exclude-kind strings         Ressource kind to exclude. Eg. 'deployment'
   -z, --exclude-namespaces strings   Namespaces to exclude. Eg. 'temp.*' as regexes. This collects all namespaces and then filters them. Don't use it with the namespace flag.
   -y, --exclude-object strings       Object to exclude. Eg. 'configmap:kube-system/kube-dns'
-  -l, --filter string                Label filter. Select only objects matching the label
+  -l, --filter string                Label selector. Select only objects matching the label
   -t, --git-timeout duration         Git operations timeout (default 5m0s)
   -g, --git-url string               Git repository URL
   -p, --healthcheck-port int         Port for answering healthchecks on /health url
@@ -92,7 +93,7 @@ The environment are the same as command line options, in uppercase, prefixed by 
 
 ```
 export KF_GIT_URL=https://user:token@github.com/myorg/myrepos.git
-export KF_LOCAL_DIR=/tmp/kfdump
+export KF_LOCAL_DIR=/tmp/clusterdump
 export KF_LOG_LEVEL=info
 export KF_EXCLUDE_KIND="pod ep rs clusterrole"
 
@@ -105,7 +106,8 @@ export KUBECONFIG=/tmp/kconfig
 You can find pre-built binaries in the [releases](https://github.com/bpineau/katafygio/releases) page,
 ready to run on your desktop or in a Kubernetes cluster.
 
-We also provide a [docker image](https://hub.docker.com/r/bpineau/katafygio/).
+We also provide a docker image on [docker hub](https://hub.docker.com/r/bpineau/katafygio/)
+and on [quay.io](https://quay.io/bpineau/katafygio).
 
 On MacOS, you can use the brew formula:
 ```bash
@@ -121,5 +123,5 @@ helm install --name kf-backups assets/helm-chart/katafygio/
 
 * [Heptio Velero](https://github.com/heptio/velero) does sophisticated clusters backups, including volumes
 * [Stash](https://github.com/appscode/stash) backups volumes
-* [etcd backup operator](https://github.com/coreos/etcd-operator)
+* [etcd backup operator](https://github.com/coreos/etcd-operator) save etcd dumps (archived project)
 

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -82,7 +82,7 @@ func runE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	evts := event.New()
-	fact := controller.NewFactory(logger, filter, resyncInt, exclusions)
+	fact := controller.NewFactory(logger, selector, resyncInt, exclusions)
 	reco := recorder.New(logger, evts, localDir, resyncInt*2, dryRun).Start()
 	obsv := observer.New(logger, restcfg, evts, fact, exclkind, namespace).Start()
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -20,7 +20,7 @@ var (
 	logLevel       string
 	logOutput      string
 	logServer      string
-	filter         string
+	selector       string
 	localDir       string
 	gitURL         string
 	gitTimeout     time.Duration
@@ -93,8 +93,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&noOwnerRef, "exclude-having-owner-ref", "w", false, "Exclude all objects having an Owner Reference")
 	bindPFlag("exclude-having-owner-ref", "exclude-having-owner-ref")
 
-	RootCmd.PersistentFlags().StringVarP(&filter, "filter", "l", "", "Label filter. Select only objects matching the label")
-	bindPFlag("filter", "filter")
+	RootCmd.PersistentFlags().StringVarP(&selector, "filter", "l", "", "Label selector. Select only objects matching the label")
+	bindPFlag("selector", "selector")
 
 	RootCmd.PersistentFlags().IntVarP(&healthP, "healthcheck-port", "p", 0, "Port for answering healthchecks on /health url")
 	bindPFlag("healthcheck-port", "healthcheck-port")
@@ -118,7 +118,7 @@ func bindConf(cmd *cobra.Command, args []string) {
 	logLevel = viper.GetString("log-level")
 	logOutput = viper.GetString("log-output")
 	logServer = viper.GetString("log-server")
-	filter = viper.GetString("filter")
+	selector = viper.GetString("filter")
 	localDir = viper.GetString("local-dir")
 	gitURL = viper.GetString("git-url")
 	gitTimeout = viper.GetDuration("git-timeout")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -52,7 +52,7 @@ type Exclusions struct {
 // Factory generate controllers
 type Factory struct {
 	logger     logger
-	filter     string
+	selector   string
 	resyncIntv time.Duration
 	exclusions *Exclusions
 }
@@ -76,18 +76,18 @@ func New(client cache.ListerWatcher,
 	notifier event.Notifier,
 	log logger,
 	name string,
-	filter string,
+	selector string,
 	resync time.Duration,
 	exclusions *Exclusions,
 ) *Controller {
 
-	selector := metav1.ListOptions{LabelSelector: filter, ResourceVersion: "0", AllowWatchBookmarks: true}
+	lopts := metav1.ListOptions{LabelSelector: selector, ResourceVersion: "0", AllowWatchBookmarks: true}
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return client.List(selector)
+			return client.List(lopts)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return client.Watch(selector)
+			return client.Watch(lopts)
 		},
 	}
 
@@ -256,10 +256,10 @@ func (c *Controller) enqueue(notif *event.Notification) {
 }
 
 // NewFactory create a controller factory
-func NewFactory(logger logger, filter string, resync int, exclusions *Exclusions) *Factory {
+func NewFactory(logger logger, selector string, resync int, exclusions *Exclusions) *Factory {
 	return &Factory{
 		logger:     logger,
-		filter:     filter,
+		selector:   selector,
 		resyncIntv: time.Duration(resync) * time.Second,
 		exclusions: exclusions,
 	}
@@ -267,5 +267,5 @@ func NewFactory(logger logger, filter string, resync int, exclusions *Exclusions
 
 // NewController create a controller.Controller
 func (f *Factory) NewController(client cache.ListerWatcher, notifier event.Notifier, name string) Interface {
-	return New(client, notifier, f.logger, name, f.filter, f.resyncIntv, f.exclusions)
+	return New(client, notifier, f.logger, name, f.selector, f.resyncIntv, f.exclusions)
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -186,23 +186,18 @@ func TestController(t *testing.T) {
 	}
 	ctrl.Stop()
 
-	gotFoo2 := false
 	for _, ev := range evt.evts {
-		// ensure cleanup filters works as expected
-		if strings.Contains(string(ev.Object), "shouldnotbethere") {
-			t.Error("object cleanup filters didn't work")
-		}
-
 		// ensure deletion notifications pops up as expected
 		if strings.Compare(ev.Key, "ns1/Bar1") == 0 && ev.Action != event.Delete {
 			t.Error("deletion notification failed")
 		}
 
-		if strings.Compare(ev.Key, "ns2/Bar2") == 0 {
-			gotFoo2 = true
+		// ensure cleanup label selectors filter works as expected
+		if strings.Contains(string(ev.Object), "shouldnotbethere") {
+			t.Error("labels selectors filters didn't work")
 		}
 
-		// ensure objet filter works as expected
+		// ensure objet name filter works as expected
 		if strings.Compare(ev.Key, "ns3/Bar3") == 0 {
 			t.Error("execludedobject filter failed")
 		}
@@ -221,9 +216,5 @@ func TestController(t *testing.T) {
 		if strings.Contains(string(ev.Object), "canary-bar4") {
 			t.Error("update didn't propagate")
 		}
-	}
-
-	if !gotFoo2 {
-		t.Errorf("we should have notified obj2")
 	}
 }


### PR DESCRIPTION
Now we have several ways to filter out un-wanted objects (by name,
by kind, by namespace, by namespace regexp, or having an ownership
ref), the "filter" workd becomes a bit overloaded.

Use the proper "selector" name (instead of "filter") for label
selectors. Internal only (keep `--filter` cli option name, so
we don't break backward compat).