### PR TITLE
Auto-publish helm chart to github

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,28 @@
+name: helm-release
+
+on:
+  push:
+    # release chart on every master merge that touch charts
+    branches:
+    - master
+    paths:
+    - 'assets/helm-chart/**'
+
+jobs:
+  publish-helm-chart:
+    name: Publish helm chart
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: Publish Helm chart
+        uses: stefanprodan/helm-gh-pages@919cd2c
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: assets/helm-chart
+          charts_url: https://bpineau.github.io/katafygio
+          branch: gh-pages
+          helm_version: 3.4.1
+

--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ On MacOS, you can use the brew formula:
 brew install bpineau/tap/katafygio
 ```
 
-You can also deploy with the provided [helm](https://helm.sh/) chart:
+You can also deploy with the provided [helm](https://helm.sh/) chart and/or repository:
 ```shell
-helm install --name kf-backups assets/helm-chart/katafygio/
+helm repo add katafygio https://bpineau.github.io/katafygio
+helm repo update
+
+helm install kube-backups katafygio/katafygio
 ```
 
 ## See Also


### PR DESCRIPTION
Use Github Actions and gh-pages to self host charts, since Helm Hub
is deprecated and frozen. Should resolve #96 .