### PR TITLE
Fix status field and uid issue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,7 +28,7 @@ import (
 var (
 	maxProcessRetry = 6
 	canaryKey       = "$katafygio canary$"
-	unexported      = []string{"selfLink", "uid", "resourceVersion", "generation", "managedFields"}
+	unexported      = []string{"selfLink", "resourceVersion", "generation", "managedFields"}
 )
 
 // Interface describe a standard kubernetes controller
@@ -222,7 +222,7 @@ func (c *Controller) processItem(key string) error {
 
 	// clear irrelevant attributes
 	uc := obj.UnstructuredContent()
-	delete(uc, "status")
+	//delete(uc, "status")
 	md := uc["metadata"].(map[string]interface{})
 	for _, attr := range unexported {
 		delete(md, attr)


### PR DESCRIPTION
When Controller will be initiated, it will delete the unwanted fields like status and some metadata fields like uid.
So, I made changes to capture the status and uid of kubernetes objects.